### PR TITLE
feat: replace startup notify with splash banner

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,3 +1,4 @@
 {
-  "packages": [".."]
+  "packages": [".."],
+  "quietStartup": true
 }

--- a/src/extensions/_init/index.ts
+++ b/src/extensions/_init/index.ts
@@ -3,12 +3,14 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 const SPLASH_ID = "pim-splash";
 
 const shortcuts = [
-  ["Ctrl+C / Ctrl+D", "quit"],
-  ["Esc", "stop the current agent"],
-  ["/", "run a command"],
-  ["@", "attach files"],
-  ["!", "run bash"],
-  ["!!", "run bash (no context)"],
+  ["Ctrl+C", "Clear editor (first) / exit (second)"],
+  ["Escape", "Cancel autocomplete / abort streaming"],
+  ["/<command>", "Slash commands", "<command>"],
+  ["/hotkeys", "Show all keyboard shortcuts"],
+  ["/settings", "Open settings menu"],
+  ["@<path>", "Attach files", "<path>"],
+  ["!<command>", "Run bash command", "<command>"],
+  ["!!<command>", "Run bash command (excluded from context)", "<command>"],
 ] as const;
 
 export default async function (pi: ExtensionAPI): Promise<void> {
@@ -34,19 +36,65 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     }
 
     const theme = ctx.ui.theme;
+    const renderKey = (key: string, muted: string | undefined): string => {
+      const padding = " ".repeat(Math.max(0, keyCol - key.length));
+      if (!muted) {
+        return theme.fg("mdCode", key + padding);
+      }
+      const idx = key.indexOf(muted);
+      if (idx === -1) {
+        return theme.fg("mdCode", key + padding);
+      }
+      return (
+        theme.fg("mdCode", key.slice(0, idx)) +
+        theme.fg("muted", muted) +
+        key.slice(idx + muted.length) +
+        padding
+      );
+    };
+
+    const title =
+      theme.bold(theme.fg("mdHeading", "PIM - Pi IMproved")) +
+      " " +
+      theme.fg("muted", `v${version}`);
     ctx.ui.setWidget(SPLASH_ID, [
-      theme.fg("accent", `PIM - Pi IMproved v${version}`),
-      "",
-      ...shortcuts.map(([k, d]) => k.padEnd(keyCol) + theme.fg("dim", d)),
+      title,
+      ...shortcuts.map(
+        ([k, d, muted]) => renderKey(k, muted) + theme.fg("dim", d)
+      ),
     ]);
     splashShown = true;
   });
 
-  pi.on("input", (_event, ctx) => {
+  const clearSplash = (ctx: {
+    ui: { setWidget: (id: string, content: undefined) => void };
+  }) => {
     if (splashShown) {
       ctx.ui.setWidget(SPLASH_ID, undefined);
       splashShown = false;
     }
+  };
+
+  pi.on("input", (_event, ctx) => {
+    clearSplash(ctx);
     return { action: "continue" };
+  });
+  pi.on("user_bash", (_event, ctx) => {
+    clearSplash(ctx);
+  });
+  pi.on("model_select", (_event, ctx) => {
+    clearSplash(ctx);
+  });
+  pi.on("thinking_level_select", (_event, ctx) => {
+    clearSplash(ctx);
+  });
+  pi.on("session_before_fork", (_event, ctx) => {
+    clearSplash(ctx);
+  });
+  pi.on("session_before_tree", (_event, ctx) => {
+    clearSplash(ctx);
+  });
+  pi.on("session_before_compact", (_event, ctx) => {
+    clearSplash(ctx);
   });
 }

--- a/src/extensions/_init/index.ts
+++ b/src/extensions/_init/index.ts
@@ -1,6 +1,17 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-export default function (pi: ExtensionAPI): void {
+const SPLASH_ID = "pim-splash";
+
+const shortcuts = [
+  ["Ctrl+C / Ctrl+D", "quit"],
+  ["Esc", "stop the current agent"],
+  ["/", "run a command"],
+  ["@", "attach files"],
+  ["!", "run bash"],
+  ["!!", "run bash (no context)"],
+] as const;
+
+export default async function (pi: ExtensionAPI): Promise<void> {
   if (typeof Bun === "undefined") {
     throw new Error(
       "Pim requires the Bun runtime.\n" +
@@ -10,7 +21,32 @@ export default function (pi: ExtensionAPI): void {
     );
   }
 
-  pi.on("session_start", async (_event, ctx) => {
-    ctx.ui.notify("PIM - Pi IMproved", "info");
+  const pkgPath = `${import.meta.dir}/../../../package.json`;
+  const { version } = (await Bun.file(pkgPath).json()) as { version: string };
+
+  const keyCol = Math.max(...shortcuts.map(([k]) => k.length)) + 2;
+
+  let splashShown = false;
+
+  pi.on("session_start", (event, ctx) => {
+    if (event.reason !== "startup" && event.reason !== "new") {
+      return;
+    }
+
+    const theme = ctx.ui.theme;
+    ctx.ui.setWidget(SPLASH_ID, [
+      theme.fg("accent", `PIM - Pi IMproved v${version}`),
+      "",
+      ...shortcuts.map(([k, d]) => k.padEnd(keyCol) + theme.fg("dim", d)),
+    ]);
+    splashShown = true;
+  });
+
+  pi.on("input", (_event, ctx) => {
+    if (splashShown) {
+      ctx.ui.setWidget(SPLASH_ID, undefined);
+      splashShown = false;
+    }
+    return { action: "continue" };
   });
 }


### PR DESCRIPTION
## Summary

- Swap the toast `ctx.ui.notify("PIM - Pi IMproved", "info")` on `session_start` for a persistent above-editor widget showing `PIM - Pi IMproved v{version}` plus a 2-column shortcut list.
- Splash auto-clears on the user's first `input` event, so the chat reverts to a clean view as soon as the user starts working.
- Only renders when `event.reason` is `"startup"` or `"new"` — resumed, forked, and reload sessions skip the splash.

Shortcuts shown: `Ctrl+C / Ctrl+D` quit, `Esc` stop the current agent, `/` run a command, `@` attach files, `!` run bash, `!!` run bash (no context).

## Test plan

- [ ] `bun run check` passes (typecheck + 242 tests + lint + format)
- [ ] Launch `pim` fresh: splash is visible above the editor with title in accent and dimmed shortcut descriptions
- [ ] Type and submit any message: splash disappears
- [ ] Run `/new`: splash reappears for the new session
- [ ] Resume a session via `/resume`: splash does NOT appear