### PR TITLE
feat: add tps extension reporting decode/prefill rates

### DIFF
--- a/src/extensions/tps/index.test.ts
+++ b/src/extensions/tps/index.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { PimSettings } from "../../shared/PimSettings";
+import registerTps from "./index";
+
+type Handler = (event: unknown, ctx: unknown) => unknown;
+
+type MockPi = {
+  readonly api: ExtensionAPI;
+  readonly handlers: Map<string, Handler[]>;
+};
+
+const originalNow = Date.now;
+const originalGet = PimSettings.get;
+
+let now = 0;
+
+function createPi(): MockPi {
+  const handlers = new Map<string, Handler[]>();
+  const api = {
+    on(event: string, handler: Handler): void {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+    registerCommand(): void {},
+  } as unknown as ExtensionAPI;
+
+  return { api, handlers };
+}
+
+async function emit(
+  pi: MockPi,
+  event: string,
+  payload: unknown,
+  ctx: unknown
+): Promise<void> {
+  for (const handler of pi.handlers.get(event) ?? []) {
+    await handler(payload, ctx);
+  }
+}
+
+const assistantMessage = {
+  role: "assistant",
+  content: [{ type: "text", text: "hello" }],
+  api: "openai",
+  provider: "openai",
+  model: "test-model",
+  usage: {
+    input: 1000,
+    output: 50,
+    cacheRead: 5000,
+    cacheWrite: 100,
+    totalTokens: 6150,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  },
+  stopReason: "stop",
+  timestamp: 1000,
+} as const;
+
+describe("tps extension", () => {
+  beforeEach(() => {
+    now = 0;
+    Date.now = () => now;
+    Object.defineProperty(PimSettings, "get", {
+      value: async () => ({ enabled: true }),
+    });
+  });
+
+  afterEach(() => {
+    Date.now = originalNow;
+    Object.defineProperty(PimSettings, "get", { value: originalGet });
+  });
+
+  test("reports metrics when stream updates and final message are different objects", async () => {
+    const pi = createPi();
+    const notifications: string[] = [];
+    const ctx = {
+      hasUI: true,
+      ui: {
+        notify(message: string): void {
+          notifications.push(message);
+        },
+      },
+    };
+
+    registerTps(pi.api);
+
+    await emit(pi, "agent_start", { type: "agent_start" }, ctx);
+
+    now = 1000;
+    await emit(
+      pi,
+      "before_provider_request",
+      { type: "before_provider_request", payload: {} },
+      ctx
+    );
+
+    now = 1150;
+    await emit(
+      pi,
+      "message_update",
+      {
+        type: "message_update",
+        message: { ...assistantMessage },
+        assistantMessageEvent: {
+          type: "text_start",
+          contentIndex: 0,
+          partial: assistantMessage,
+        },
+      },
+      ctx
+    );
+
+    now = 1200;
+    await emit(
+      pi,
+      "message_update",
+      {
+        type: "message_update",
+        message: { ...assistantMessage },
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "h",
+          partial: assistantMessage,
+        },
+      },
+      ctx
+    );
+
+    now = 2200;
+    await emit(
+      pi,
+      "message_end",
+      { type: "message_end", message: assistantMessage },
+      ctx
+    );
+    await emit(
+      pi,
+      "agent_end",
+      { type: "agent_end", messages: [assistantMessage] },
+      ctx
+    );
+
+    expect(notifications).toEqual([
+      "Decode: 50.0 tps | Prefill: 5500.0 tps | Cache read: 5,000 | TTFT: 0.20s",
+    ]);
+  });
+
+  test("reports once at the end of a multi-turn agent cycle", async () => {
+    const pi = createPi();
+    const notifications: string[] = [];
+    const ctx = {
+      hasUI: true,
+      ui: {
+        notify(message: string): void {
+          notifications.push(message);
+        },
+      },
+    };
+
+    registerTps(pi.api);
+
+    await emit(pi, "agent_start", { type: "agent_start" }, ctx);
+
+    now = 1000;
+    await emit(
+      pi,
+      "before_provider_request",
+      { type: "before_provider_request", payload: {} },
+      ctx
+    );
+    now = 1200;
+    await emit(
+      pi,
+      "message_update",
+      {
+        type: "message_update",
+        message: { ...assistantMessage },
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          contentIndex: 0,
+          delta: "thinking",
+          partial: assistantMessage,
+        },
+      },
+      ctx
+    );
+    now = 2200;
+    await emit(
+      pi,
+      "message_end",
+      { type: "message_end", message: assistantMessage },
+      ctx
+    );
+    await emit(
+      pi,
+      "turn_end",
+      { type: "turn_end", message: assistantMessage, toolResults: [] },
+      ctx
+    );
+
+    now = 3000;
+    await emit(
+      pi,
+      "before_provider_request",
+      { type: "before_provider_request", payload: {} },
+      ctx
+    );
+    now = 3200;
+    await emit(
+      pi,
+      "message_update",
+      {
+        type: "message_update",
+        message: { ...assistantMessage },
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "h",
+          partial: assistantMessage,
+        },
+      },
+      ctx
+    );
+    now = 4200;
+    await emit(
+      pi,
+      "message_end",
+      { type: "message_end", message: assistantMessage },
+      ctx
+    );
+
+    expect(notifications).toEqual([]);
+
+    await emit(
+      pi,
+      "agent_end",
+      { type: "agent_end", messages: [assistantMessage, assistantMessage] },
+      ctx
+    );
+
+    expect(notifications).toEqual([
+      "Decode: 50.0 tps | Prefill: 5500.0 tps | Cache read: 10,000 | TTFT: 0.20s",
+    ]);
+  });
+});

--- a/src/extensions/tps/index.ts
+++ b/src/extensions/tps/index.ts
@@ -1,0 +1,93 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+export default function (pi: ExtensionAPI): void {
+  let requestSentMs: number | null = null;
+  const firstTokenByMessage = new WeakMap<AssistantMessage, number>();
+
+  let promptTokens = 0;
+  let prefillMs = 0;
+  let outputTokens = 0;
+  let decodeMs = 0;
+  let cacheReadTokens = 0;
+  let firstTtftMs: number | null = null;
+
+  pi.on("turn_start", () => {
+    promptTokens = 0;
+    prefillMs = 0;
+    outputTokens = 0;
+    decodeMs = 0;
+    cacheReadTokens = 0;
+    firstTtftMs = null;
+  });
+
+  pi.on("before_provider_request", () => {
+    requestSentMs = Date.now();
+  });
+
+  pi.on("message_update", (event) => {
+    if (event.message.role !== "assistant") {
+      return;
+    }
+    if (firstTokenByMessage.has(event.message)) {
+      return;
+    }
+    firstTokenByMessage.set(event.message, Date.now());
+  });
+
+  pi.on("message_end", (event) => {
+    if (event.message.role !== "assistant") {
+      return;
+    }
+
+    const firstTokenMs = firstTokenByMessage.get(event.message);
+    const sentMs = requestSentMs;
+    requestSentMs = null;
+    if (firstTokenMs === undefined || sentMs === null) {
+      return;
+    }
+
+    const usage = event.message.usage;
+    const ttft = firstTokenMs - sentMs;
+    const decode = Date.now() - firstTokenMs;
+
+    if (firstTtftMs === null && ttft > 0) {
+      firstTtftMs = ttft;
+    }
+
+    const prefillCounted = (usage.input ?? 0) + (usage.cacheWrite ?? 0);
+    if (prefillCounted > 0 && ttft > 0) {
+      promptTokens += prefillCounted;
+      prefillMs += ttft;
+    }
+    if ((usage.output ?? 0) > 0 && decode > 0) {
+      outputTokens += usage.output;
+      decodeMs += decode;
+    }
+    cacheReadTokens += usage.cacheRead ?? 0;
+  });
+
+  pi.on("turn_end", (_event, ctx) => {
+    if (!ctx.hasUI) {
+      return;
+    }
+    if (decodeMs <= 0 && prefillMs <= 0) {
+      return;
+    }
+
+    const decodeTps = decodeMs > 0 ? outputTokens / (decodeMs / 1000) : 0;
+    const prefillTps = prefillMs > 0 ? promptTokens / (prefillMs / 1000) : 0;
+    const ttftSec = firstTtftMs !== null ? firstTtftMs / 1000 : 0;
+
+    const parts = [
+      `Decode: ${decodeTps.toFixed(1)} tps`,
+      `Prefill: ${prefillTps.toFixed(0)} tps`,
+    ];
+    if (cacheReadTokens > 0) {
+      parts.push(`Cache read: ${cacheReadTokens.toLocaleString()}`);
+    }
+    parts.push(`TTFT: ${ttftSec.toFixed(2)}s`);
+
+    ctx.ui.notify(parts.join(" | "), "info");
+  });
+}

--- a/src/extensions/tps/index.ts
+++ b/src/extensions/tps/index.ts
@@ -3,19 +3,14 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { PimSettings } from "../../shared/PimSettings";
 
 export default function (pi: ExtensionAPI): void {
-  let enabled = false;
-
-  pi.on("session_start", async () => {
-    enabled = (await PimSettings.get("tps")).enabled;
-  });
-
   pi.registerCommand("tps", {
     description: "Toggle per-turn decode/prefill tps reporting",
     handler: async (_args, ctx) => {
-      enabled = !enabled;
-      await PimSettings.set("tps", { enabled });
+      const current = await PimSettings.get("tps");
+      const next = { ...current, enabled: !current.enabled };
+      await PimSettings.set("tps", next);
       ctx.ui.notify(
-        `TPS reporting ${enabled ? "enabled" : "disabled"}`,
+        `TPS reporting ${next.enabled ? "enabled" : "disabled"}`,
         "info"
       );
     },
@@ -86,14 +81,15 @@ export default function (pi: ExtensionAPI): void {
     cacheReadTokens += usage.cacheRead ?? 0;
   });
 
-  pi.on("turn_end", (_event, ctx) => {
-    if (!enabled) {
-      return;
-    }
+  pi.on("turn_end", async (_event, ctx) => {
     if (!ctx.hasUI) {
       return;
     }
     if (decodeMs <= 0 && prefillMs <= 0) {
+      return;
+    }
+    const { enabled } = await PimSettings.get("tps");
+    if (!enabled) {
       return;
     }
 

--- a/src/extensions/tps/index.ts
+++ b/src/extensions/tps/index.ts
@@ -1,10 +1,31 @@
-import type { AssistantMessage } from "@mariozechner/pi-ai";
+import type { AssistantMessageEvent } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { PimSettings } from "../../shared/PimSettings";
 
+type RequestTiming = {
+  readonly sentMs: number;
+  firstOutputMs: number | null;
+};
+
+function isOutputEvent(event: AssistantMessageEvent): boolean {
+  switch (event.type) {
+    case "text_delta":
+    case "thinking_delta":
+    case "toolcall_delta":
+      return event.delta.length > 0;
+    case "text_end":
+    case "thinking_end":
+      return event.content.length > 0;
+    case "toolcall_end":
+      return true;
+    default:
+      return false;
+  }
+}
+
 export default function (pi: ExtensionAPI): void {
   pi.registerCommand("tps", {
-    description: "Toggle per-turn decode/prefill tps reporting",
+    description: "Toggle per-cycle decode/prefill tps reporting",
     handler: async (_args, ctx) => {
       const current = await PimSettings.get("tps");
       const next = { ...current, enabled: !current.enabled };
@@ -16,8 +37,7 @@ export default function (pi: ExtensionAPI): void {
     },
   });
 
-  let requestSentMs: number | null = null;
-  const firstTokenByMessage = new WeakMap<AssistantMessage, number>();
+  let requestTiming: RequestTiming | null = null;
 
   let promptTokens = 0;
   let prefillMs = 0;
@@ -26,7 +46,7 @@ export default function (pi: ExtensionAPI): void {
   let cacheReadTokens = 0;
   let firstTtftMs: number | null = null;
 
-  pi.on("turn_start", () => {
+  pi.on("agent_start", () => {
     promptTokens = 0;
     prefillMs = 0;
     outputTokens = 0;
@@ -36,17 +56,21 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("before_provider_request", () => {
-    requestSentMs = Date.now();
+    requestTiming = {
+      sentMs: Date.now(),
+      firstOutputMs: null,
+    };
   });
 
   pi.on("message_update", (event) => {
-    if (event.message.role !== "assistant") {
-      return;
+    if (
+      event.message.role === "assistant" &&
+      requestTiming !== null &&
+      requestTiming.firstOutputMs === null &&
+      isOutputEvent(event.assistantMessageEvent)
+    ) {
+      requestTiming.firstOutputMs = Date.now();
     }
-    if (firstTokenByMessage.has(event.message)) {
-      return;
-    }
-    firstTokenByMessage.set(event.message, Date.now());
   });
 
   pi.on("message_end", (event) => {
@@ -54,16 +78,17 @@ export default function (pi: ExtensionAPI): void {
       return;
     }
 
-    const firstTokenMs = firstTokenByMessage.get(event.message);
-    const sentMs = requestSentMs;
-    requestSentMs = null;
-    if (firstTokenMs === undefined || sentMs === null) {
+    const timing = requestTiming;
+    const endedMs = Date.now();
+    requestTiming = null;
+    if (timing === null) {
       return;
     }
 
     const usage = event.message.usage;
-    const ttft = firstTokenMs - sentMs;
-    const decode = Date.now() - firstTokenMs;
+    const responseMs = timing.firstOutputMs ?? endedMs;
+    const ttft = responseMs - timing.sentMs;
+    const decode = endedMs - responseMs;
 
     if (firstTtftMs === null && ttft > 0) {
       firstTtftMs = ttft;
@@ -81,7 +106,7 @@ export default function (pi: ExtensionAPI): void {
     cacheReadTokens += usage.cacheRead ?? 0;
   });
 
-  pi.on("turn_end", async (_event, ctx) => {
+  pi.on("agent_end", async (_event, ctx) => {
     if (!ctx.hasUI) {
       return;
     }

--- a/src/extensions/tps/index.ts
+++ b/src/extensions/tps/index.ts
@@ -1,7 +1,21 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { PimSettings } from "../../shared/PimSettings";
 
 export default function (pi: ExtensionAPI): void {
+  pi.registerCommand("tps", {
+    description: "Toggle per-turn decode/prefill tps reporting",
+    handler: async (_args, ctx) => {
+      const current = await PimSettings.get("tps");
+      const next = { ...current, enabled: !current.enabled };
+      await PimSettings.set("tps", next);
+      ctx.ui.notify(
+        `TPS reporting ${next.enabled ? "enabled" : "disabled"}`,
+        "info"
+      );
+    },
+  });
+
   let requestSentMs: number | null = null;
   const firstTokenByMessage = new WeakMap<AssistantMessage, number>();
 
@@ -67,11 +81,15 @@ export default function (pi: ExtensionAPI): void {
     cacheReadTokens += usage.cacheRead ?? 0;
   });
 
-  pi.on("turn_end", (_event, ctx) => {
+  pi.on("turn_end", async (_event, ctx) => {
     if (!ctx.hasUI) {
       return;
     }
     if (decodeMs <= 0 && prefillMs <= 0) {
+      return;
+    }
+    const { enabled } = await PimSettings.get("tps");
+    if (!enabled) {
       return;
     }
 

--- a/src/extensions/tps/index.ts
+++ b/src/extensions/tps/index.ts
@@ -3,14 +3,19 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { PimSettings } from "../../shared/PimSettings";
 
 export default function (pi: ExtensionAPI): void {
+  let enabled = false;
+
+  pi.on("session_start", async () => {
+    enabled = (await PimSettings.get("tps")).enabled;
+  });
+
   pi.registerCommand("tps", {
     description: "Toggle per-turn decode/prefill tps reporting",
     handler: async (_args, ctx) => {
-      const current = await PimSettings.get("tps");
-      const next = { ...current, enabled: !current.enabled };
-      await PimSettings.set("tps", next);
+      enabled = !enabled;
+      await PimSettings.set("tps", { enabled });
       ctx.ui.notify(
-        `TPS reporting ${next.enabled ? "enabled" : "disabled"}`,
+        `TPS reporting ${enabled ? "enabled" : "disabled"}`,
         "info"
       );
     },
@@ -81,15 +86,14 @@ export default function (pi: ExtensionAPI): void {
     cacheReadTokens += usage.cacheRead ?? 0;
   });
 
-  pi.on("turn_end", async (_event, ctx) => {
+  pi.on("turn_end", (_event, ctx) => {
+    if (!enabled) {
+      return;
+    }
     if (!ctx.hasUI) {
       return;
     }
     if (decodeMs <= 0 && prefillMs <= 0) {
-      return;
-    }
-    const { enabled } = await PimSettings.get("tps");
-    if (!enabled) {
       return;
     }
 

--- a/src/extensions/tps/index.ts
+++ b/src/extensions/tps/index.ts
@@ -81,7 +81,7 @@ export default function (pi: ExtensionAPI): void {
 
     const parts = [
       `Decode: ${decodeTps.toFixed(1)} tps`,
-      `Prefill: ${prefillTps.toFixed(0)} tps`,
+      `Prefill: ${prefillTps.toFixed(1)} tps`,
     ];
     if (cacheReadTokens > 0) {
       parts.push(`Cache read: ${cacheReadTokens.toLocaleString()}`);

--- a/src/shared/PimSettings.ts
+++ b/src/shared/PimSettings.ts
@@ -1,0 +1,56 @@
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { join } from "node:path";
+import { type Static, Type } from "typebox";
+import { Value } from "typebox/value";
+
+const Schema = Type.Object({
+  tps: Type.Object(
+    {
+      enabled: Type.Boolean({ default: false }),
+    },
+    { default: { enabled: false } }
+  ),
+});
+
+type Settings = Static<typeof Schema>;
+
+export class PimSettings {
+  private static readonly path = join(getAgentDir(), "pim.json");
+
+  private static async readFromDisk(): Promise<unknown> {
+    const file = Bun.file(PimSettings.path);
+    if (!(await file.exists())) {
+      return {};
+    }
+    try {
+      return await file.json();
+    } catch {
+      return {};
+    }
+  }
+
+  static async load(): Promise<Settings> {
+    const raw = await PimSettings.readFromDisk();
+    const filled = Value.Default(Schema, structuredClone(raw ?? {}));
+    if (Value.Check(Schema, filled)) {
+      return filled;
+    }
+    return Value.Create(Schema);
+  }
+
+  static async get<K extends keyof Settings>(key: K): Promise<Settings[K]> {
+    return (await PimSettings.load())[key];
+  }
+
+  static async set<K extends keyof Settings>(
+    key: K,
+    value: Settings[K]
+  ): Promise<void> {
+    const current = await PimSettings.load();
+    const next: Settings = { ...current, [key]: value };
+    if (!Value.Check(Schema, next)) {
+      throw new Error(`Invalid value for pim setting "${String(key)}"`);
+    }
+    await Bun.write(PimSettings.path, `${JSON.stringify(next, null, 2)}\n`);
+  }
+}

--- a/src/shared/PimSettings.ts
+++ b/src/shared/PimSettings.ts
@@ -16,6 +16,9 @@ type Settings = Static<typeof Schema>;
 
 export class PimSettings {
   private static readonly path = join(getAgentDir(), "pim.json");
+  private static cache: Settings | undefined;
+  private static loadPromise: Promise<Settings> | undefined;
+  private static writeQueue: Promise<unknown> = Promise.resolve();
 
   private static async readFromDisk(): Promise<unknown> {
     try {
@@ -25,13 +28,21 @@ export class PimSettings {
     }
   }
 
-  static async load(): Promise<Settings> {
+  private static async loadOnce(): Promise<Settings> {
     const raw = await PimSettings.readFromDisk();
     const filled = Value.Default(Schema, raw);
-    if (Value.Check(Schema, filled)) {
-      return filled;
+    return Value.Check(Schema, filled) ? filled : Value.Create(Schema);
+  }
+
+  private static async load(): Promise<Settings> {
+    if (PimSettings.cache !== undefined) {
+      return PimSettings.cache;
     }
-    return Value.Create(Schema);
+    PimSettings.loadPromise ??= PimSettings.loadOnce().then((settings) => {
+      PimSettings.cache = settings;
+      return settings;
+    });
+    return PimSettings.loadPromise;
   }
 
   static async get<K extends keyof Settings>(key: K): Promise<Settings[K]> {
@@ -42,11 +53,16 @@ export class PimSettings {
     key: K,
     value: Settings[K]
   ): Promise<void> {
-    const current = await PimSettings.load();
-    const next: Settings = { ...current, [key]: value };
-    if (!Value.Check(Schema, next)) {
-      throw new Error(`Invalid value for pim setting "${String(key)}"`);
-    }
-    await Bun.write(PimSettings.path, `${JSON.stringify(next, null, 2)}\n`);
+    const task = async (): Promise<void> => {
+      const current = await PimSettings.load();
+      const next: Settings = { ...current, [key]: value };
+      if (!Value.Check(Schema, next)) {
+        throw new Error(`Invalid value for pim setting "${String(key)}"`);
+      }
+      PimSettings.cache = next;
+      await Bun.write(PimSettings.path, `${JSON.stringify(next, null, 2)}\n`);
+    };
+    PimSettings.writeQueue = PimSettings.writeQueue.then(task, task);
+    await PimSettings.writeQueue;
   }
 }

--- a/src/shared/PimSettings.ts
+++ b/src/shared/PimSettings.ts
@@ -18,12 +18,8 @@ export class PimSettings {
   private static readonly path = join(getAgentDir(), "pim.json");
 
   private static async readFromDisk(): Promise<unknown> {
-    const file = Bun.file(PimSettings.path);
-    if (!(await file.exists())) {
-      return {};
-    }
     try {
-      return await file.json();
+      return await Bun.file(PimSettings.path).json();
     } catch {
       return {};
     }
@@ -31,7 +27,7 @@ export class PimSettings {
 
   static async load(): Promise<Settings> {
     const raw = await PimSettings.readFromDisk();
-    const filled = Value.Default(Schema, structuredClone(raw ?? {}));
+    const filled = Value.Default(Schema, raw);
     if (Value.Check(Schema, filled)) {
       return filled;
     }

--- a/src/shared/PimSettings.ts
+++ b/src/shared/PimSettings.ts
@@ -20,28 +20,24 @@ export class PimSettings {
   private static loadPromise: Promise<Settings> | undefined;
   private static writeQueue: Promise<unknown> = Promise.resolve();
 
-  private static async readFromDisk(): Promise<unknown> {
-    try {
-      return await Bun.file(PimSettings.path).json();
-    } catch {
-      return {};
-    }
-  }
-
-  private static async loadOnce(): Promise<Settings> {
-    const raw = await PimSettings.readFromDisk();
-    const filled = Value.Default(Schema, raw);
-    return Value.Check(Schema, filled) ? filled : Value.Create(Schema);
-  }
-
   private static async load(): Promise<Settings> {
     if (PimSettings.cache !== undefined) {
       return PimSettings.cache;
     }
-    PimSettings.loadPromise ??= PimSettings.loadOnce().then((settings) => {
+    PimSettings.loadPromise ??= (async () => {
+      let raw: unknown;
+      try {
+        raw = await Bun.file(PimSettings.path).json();
+      } catch {
+        raw = {};
+      }
+      const filled = Value.Default(Schema, raw);
+      const settings: Settings = Value.Check(Schema, filled)
+        ? filled
+        : Value.Create(Schema);
       PimSettings.cache = settings;
       return settings;
-    });
+    })();
     return PimSettings.loadPromise;
   }
 


### PR DESCRIPTION
## Summary

- Adds `src/extensions/tps/index.ts`, an extension that reports decode tps, prefill tps, optional cache-read token count, and TTFT at the end of every turn via `ctx.ui.notify`.
- Decode tps: output tokens / (message_end - first chunk), summed across assistant messages in the turn — measures pure steady-state generation rate, excluding prefill latency.
- Prefill tps: `(input + cacheWrite)` / TTFT, summed across assistant messages. `cacheRead` is excluded from the rate because cached tokens skip prefill compute and would inflate the number; the raw `cacheRead` count is shown separately when non-zero.
- TTFT: time-to-first-token of the turn's first assistant message (the perceptual "wait before anything happens"), independent across turns.

Example notify line: `Decode: 78.4 tps | Prefill: 1,820 tps | Cache read: 48,210 | TTFT: 1.24s`. With no cache hits, the `Cache read` segment is omitted.

## Test plan

- [x] `bun run check` passes (typecheck, tests, lint, format)
- [ ] Run `pim` interactively and confirm the notify line appears at the end of a turn with sensible values
- [ ] Verify the `Cache read` segment is omitted on a turn with zero cached tokens