### PR TITLE
fix(telegram): fall back to streamed text when final message has no content

### DIFF
--- a/src/telegram/Renderer.ts
+++ b/src/telegram/Renderer.ts
@@ -43,6 +43,8 @@ export class Renderer {
   private editTimer: Timer | undefined;
   private thinking = "";
   private narration = "";
+  private currentMessageText = "";
+  private streamedFinalText = "";
   private pendingNarrationCount = 0;
   private lastRendered = "";
   private stopped = false;
@@ -80,6 +82,7 @@ export class Renderer {
       if (update.type === "text_delta") {
         this.flushThinking();
         this.narration += update.delta ?? "";
+        this.currentMessageText += update.delta ?? "";
         return;
       }
       if (update.type === "text_end") {
@@ -93,6 +96,7 @@ export class Renderer {
     if (event.type === "message_start") {
       this.flushThinking();
       this.narration = "";
+      this.currentMessageText = "";
       this.pendingNarrationCount = 0;
       return;
     }
@@ -132,8 +136,11 @@ export class Renderer {
     this.flushThinking();
     this.narration = "";
     await this.flushEdit(state);
-    if (finalText.trim()) {
-      await this.sendFinal(finalText);
+    const textToSend = finalText.trim()
+      ? finalText
+      : this.streamedFinalText.trim();
+    if (textToSend) {
+      await this.sendFinal(textToSend);
     }
   }
 
@@ -213,17 +220,20 @@ export class Renderer {
       readonly stopReason?: string;
     };
     const isFinal = msg.role === "assistant" && msg.stopReason !== "toolUse";
-    if (isFinal && this.pendingNarrationCount > 0) {
-      let removed = 0;
-      for (let i = 0; i < this.pendingNarrationCount; i++) {
-        if (this.entries.at(-1)?.kind !== "narration") {
-          break;
+    if (isFinal) {
+      this.streamedFinalText = this.currentMessageText;
+      if (this.pendingNarrationCount > 0) {
+        let removed = 0;
+        for (let i = 0; i < this.pendingNarrationCount; i++) {
+          if (this.entries.at(-1)?.kind !== "narration") {
+            break;
+          }
+          this.entries.pop();
+          removed += 1;
         }
-        this.entries.pop();
-        removed += 1;
-      }
-      if (removed > 0) {
-        this.scheduleEdit();
+        if (removed > 0) {
+          this.scheduleEdit();
+        }
       }
     }
     this.pendingNarrationCount = 0;


### PR DESCRIPTION
## Summary

- If `agent.messages.at(-1).content` ends up with no text blocks despite `text_delta`/`text_end` firing during the turn, `Bot.extractFinalResult` returns `""` and `Renderer.finish` skips `sendFinal`. Combined with `settleMessageNarrations` popping the in-flight narrations from the status, the user sees nothing at all.
- `Renderer` now buffers the in-flight assistant text per message (`currentMessageText`, reset on `message_start`, appended on `text_delta`) and snapshots it to `streamedFinalText` when the message resolves as final (`stopReason !== "toolUse"`) - before popping the narration entries.
- `finish()` falls back to `streamedFinalText` when the `finalText` argument is empty/whitespace.

The "streamed-but-empty-content" scenario is narrow under normal providers, but the user-visible failure is a vanished answer, so worth the defensive fix.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/telegram/` - 72 pass
- [ ] Manual: trigger a long turn that previously dropped the final message; confirm the text now arrives