### PR TITLE
fix(bash): don't deadlock when a backgrounded child inherits the pipe

### DIFF
--- a/src/extensions/bash/run.test.ts
+++ b/src/extensions/bash/run.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { runBashCommand } from "./run";
-import { STREAM_HEAD_BYTES, STREAM_TAIL_BYTES } from "./schema";
+import { KILL_GRACE_MS, STREAM_HEAD_BYTES, STREAM_TAIL_BYTES } from "./schema";
 
 describe("runBashCommand (integration)", () => {
   test("captures stdout from a successful command", async () => {
@@ -46,6 +46,39 @@ describe("runBashCommand (integration)", () => {
     setTimeout(() => ctrl.abort(), 50);
     const r = await promise;
     expect(r.aborted).toBe(true);
+  });
+
+  test("returns promptly when a backgrounded child inherits the pipe", async () => {
+    const startedAt = Date.now();
+    const r = await runBashCommand(
+      "nohup sleep 47 > /dev/null 2>&1 & disown; echo done",
+      5000,
+      undefined,
+      process.cwd()
+    );
+    const elapsed = Date.now() - startedAt;
+    expect(r.exitCode).toBe(0);
+    expect(r.timedOut).toBe(false);
+    expect(r.stdout.text.trim()).toBe("done");
+    expect(elapsed).toBeLessThan(2000);
+    // clean up the orphaned sleep so it doesn't linger
+    try {
+      Bun.spawnSync({ cmd: ["pkill", "-f", "sleep 47"] });
+    } catch {}
+  });
+
+  test("timeout kills the whole process group", async () => {
+    const marker = "sleep 41";
+    const startedAt = Date.now();
+    const r = await runBashCommand(marker, 500, undefined, process.cwd());
+    const elapsed = Date.now() - startedAt;
+    expect(r.timedOut).toBe(true);
+    expect(r.exitCode === null || r.exitCode !== 0).toBe(true);
+    expect(elapsed).toBeLessThan(KILL_GRACE_MS + 2000);
+    // wait briefly for SIGKILL grace then confirm no stray sleep 41 remains
+    await new Promise((resolve) => setTimeout(resolve, KILL_GRACE_MS + 500));
+    const probe = Bun.spawnSync({ cmd: ["pgrep", "-f", marker] });
+    expect(probe.exitCode).not.toBe(0);
   });
 
   test("truncates very large stdout", async () => {

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -69,16 +69,8 @@ export async function runBashCommand(
   // fds and keep the pipes open after bash exits, so we must not block on
   // EOF. We race proc.exited against a wall-clock timeout instead, then
   // cancel the streams to release the pipes.
-  const stdoutDrain = drain(
-    proc.stdout as unknown as ReadableStream<Uint8Array>,
-    stdoutCap
-  );
-  const stderrDrain = drain(
-    proc.stderr as unknown as ReadableStream<Uint8Array>,
-    stderrCap
-  );
-  void stdoutDrain;
-  void stderrDrain;
+  void drain(proc.stdout as unknown as ReadableStream<Uint8Array>, stdoutCap);
+  void drain(proc.stderr as unknown as ReadableStream<Uint8Array>, stderrCap);
 
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   const exitedPromise = proc.exited.then(() => "exited" as const);
@@ -136,12 +128,11 @@ export async function runBashCommand(
     if (signal) {
       signal.removeEventListener("abort", onAbort);
     }
-    try {
-      proc.stdout?.cancel();
-    } catch {}
-    try {
-      proc.stderr?.cancel();
-    } catch {}
+    for (const stream of [proc.stdout, proc.stderr]) {
+      try {
+        stream?.cancel();
+      } catch {}
+    }
   }
 
   return {

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -19,8 +19,25 @@ async function drain(
         cap.push(value);
       }
     }
+  } catch {
+    // stream cancelled; drop remaining bytes
   } finally {
-    reader.releaseLock();
+    try {
+      reader.releaseLock();
+    } catch {}
+  }
+}
+
+function killGroup(pid: number | undefined, sig: NodeJS.Signals): void {
+  if (pid === undefined) {
+    return;
+  }
+  try {
+    process.kill(-pid, sig);
+  } catch {
+    try {
+      process.kill(pid, sig);
+    } catch {}
   }
 }
 
@@ -34,8 +51,11 @@ export async function runBashCommand(
   const stdoutCap = new StreamCapture();
   const stderrCap = new StreamCapture();
 
+  // setsid puts bash and all descendants into a fresh process group with
+  // pgid == proc.pid, so we can signal the whole tree on timeout/abort
+  // instead of leaving backgrounded grandchildren alive holding our pipes.
   const proc = Bun.spawn({
-    cmd: ["bash", "-lc", command],
+    cmd: ["setsid", "bash", "-lc", command],
     cwd,
     stdout: "pipe",
     stderr: "pipe",
@@ -44,47 +64,84 @@ export async function runBashCommand(
 
   let timedOut = false;
   let aborted = false;
-  let killTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const timeoutHandle = setTimeout(() => {
-    timedOut = true;
-    try {
-      proc.kill("SIGTERM");
-    } catch {}
-    killTimer = setTimeout(() => {
-      try {
-        proc.kill("SIGKILL");
-      } catch {}
-    }, KILL_GRACE_MS);
-  }, timeoutMs);
+  // Fire-and-forget drains: a backgrounded child can inherit the subshell's
+  // fds and keep the pipes open after bash exits, so we must not block on
+  // EOF. We race proc.exited against a wall-clock timeout instead, then
+  // cancel the streams to release the pipes.
+  const stdoutDrain = drain(
+    proc.stdout as unknown as ReadableStream<Uint8Array>,
+    stdoutCap
+  );
+  const stderrDrain = drain(
+    proc.stderr as unknown as ReadableStream<Uint8Array>,
+    stderrCap
+  );
+  void stdoutDrain;
+  void stderrDrain;
 
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const exitedPromise = proc.exited.then(() => "exited" as const);
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+
+  let abortResolve: ((v: "aborted") => void) | null = null;
+  const abortPromise = new Promise<"aborted">((resolve) => {
+    abortResolve = resolve;
+  });
   const onAbort = () => {
     aborted = true;
-    try {
-      proc.kill("SIGTERM");
-    } catch {}
+    abortResolve?.("aborted");
   };
   if (signal) {
-    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
   }
 
   let exitCode: number | null = null;
   let signalCode: NodeJS.Signals | null = null;
   try {
-    await Promise.all([
-      drain(proc.stdout as unknown as ReadableStream<Uint8Array>, stdoutCap),
-      drain(proc.stderr as unknown as ReadableStream<Uint8Array>, stderrCap),
+    const result = await Promise.race([
+      exitedPromise,
+      timeoutPromise,
+      abortPromise,
     ]);
-    exitCode = await proc.exited;
+
+    if (result === "timeout") {
+      timedOut = true;
+    }
+
+    if (result !== "exited") {
+      killGroup(proc.pid, "SIGTERM");
+      const sigkillTimer = setTimeout(() => {
+        killGroup(proc.pid, "SIGKILL");
+      }, KILL_GRACE_MS);
+      try {
+        await proc.exited;
+      } finally {
+        clearTimeout(sigkillTimer);
+      }
+    }
+
+    exitCode = proc.exitCode ?? null;
     signalCode = (proc.signalCode as NodeJS.Signals | null | undefined) ?? null;
   } finally {
-    clearTimeout(timeoutHandle);
-    if (killTimer) {
-      clearTimeout(killTimer);
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
     }
     if (signal) {
       signal.removeEventListener("abort", onAbort);
     }
+    try {
+      proc.stdout?.cancel();
+    } catch {}
+    try {
+      proc.stderr?.cancel();
+    } catch {}
   }
 
   return {


### PR DESCRIPTION
## Summary

- The bash extension awaited stream EOF on stdout/stderr before returning. When a command backgrounds a long-running child (e.g. `nohup server &; sleep 3; cat log`), the child inherits the subshell's fds and keeps the pipes open after bash exits — `drain()` then waits forever and the tool call hangs until the harness-level timeout.
- The internal `timeoutMs` didn't help either: it called `proc.kill` on the bash subshell PID, but by then bash had already exited and the backgrounded grandchildren weren't its direct descendants.
- Fix races `proc.exited` against a wall-clock timeout (drains run fire-and-forget; streams are cancelled on exit to release inherited fds) and spawns under `setsid` so timeout/abort can signal the whole process group.