### PR TITLE
fix(bash): tighten cleanup paths

### DIFF
--- a/bin/pim.ts
+++ b/bin/pim.ts
@@ -74,6 +74,15 @@ const proc = Bun.spawn({
   stdio: ["inherit", "inherit", "inherit"],
   env: process.env,
 });
+// Forward shutdown signals so the pi subprocess (and its bash subtrees)
+// get a chance to tear down instead of being orphaned when this launcher dies.
+for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+  process.once(sig, () => {
+    try {
+      proc.kill(sig);
+    } catch {}
+  });
+}
 const exitCode = await proc.exited;
 const signalCode = proc.signalCode as NodeJS.Signals | null;
 if (signalCode) {

--- a/bin/pim.ts
+++ b/bin/pim.ts
@@ -74,8 +74,7 @@ const proc = Bun.spawn({
   stdio: ["inherit", "inherit", "inherit"],
   env: process.env,
 });
-// Forward shutdown signals so the pi subprocess (and its bash subtrees)
-// get a chance to tear down instead of being orphaned when this launcher dies.
+// Forward shutdown signals so pi's bash subtrees aren't orphaned on the host.
 for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
   process.once(sig, () => {
     try {

--- a/src/extensions/bash/index.ts
+++ b/src/extensions/bash/index.ts
@@ -26,7 +26,9 @@ function installShutdownHandlers(): void {
   // still runs.
   for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
     process.once(sig, () => {
-      killAllActiveBashGroups(sig);
+      try {
+        killAllActiveBashGroups(sig);
+      } catch {}
       process.kill(process.pid, sig);
     });
   }

--- a/src/extensions/bash/index.ts
+++ b/src/extensions/bash/index.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Renderer } from "../../shared/Renderer";
 import { Tools } from "../../shared/Tools";
 import { detailsOf, formatResult, isErrorResult } from "./format";
-import { runBashCommand } from "./run";
+import { killAllActiveBashGroups, runBashCommand } from "./run";
 import {
   type BashInput,
   bashSchema,
@@ -13,7 +13,27 @@ import {
 
 const PREVIEW_LINES = 5;
 
+let signalHandlersInstalled = false;
+
+function installShutdownHandlers(): void {
+  if (signalHandlersInstalled) {
+    return;
+  }
+  signalHandlersInstalled = true;
+  // Sweep bash subtrees that escaped our process group (double-forked
+  // daemons via their own setsid) or that the parent harness is about to
+  // strand by signalling us. Re-raise the signal so the default handler
+  // still runs.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+    process.once(sig, () => {
+      killAllActiveBashGroups(sig);
+      process.kill(process.pid, sig);
+    });
+  }
+}
+
 export default function (pi: ExtensionAPI): void {
+  installShutdownHandlers();
   Tools.register(pi, {
     name: "bash",
     label: "bash",

--- a/src/extensions/bash/run.test.ts
+++ b/src/extensions/bash/run.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { runBashCommand } from "./run";
-import { KILL_GRACE_MS, STREAM_HEAD_BYTES, STREAM_TAIL_BYTES } from "./schema";
+import { killAllActiveBashGroups, runBashCommand } from "./run";
+import {
+  DRAIN_GRACE_MS,
+  KILL_GRACE_MS,
+  STREAM_HEAD_BYTES,
+  STREAM_TAIL_BYTES,
+} from "./schema";
 
 describe("runBashCommand (integration)", () => {
   test("captures stdout from a successful command", async () => {
@@ -79,6 +84,65 @@ describe("runBashCommand (integration)", () => {
     await new Promise((resolve) => setTimeout(resolve, KILL_GRACE_MS + 500));
     const probe = Bun.spawnSync({ cmd: ["pgrep", "-f", marker] });
     expect(probe.exitCode).not.toBe(0);
+  });
+
+  test("does not crash on timeout while drains still hold readers", async () => {
+    // Regression: stream.cancel() on a locked stream rejects (Bun throws
+    // synchronously). Drains run fire-and-forget, so when a quiet command
+    // times out (no output → drain blocked on read), the finally hits
+    // cancel before drain has released. Unhandled rejection would crash Bun.
+    const rejections: unknown[] = [];
+    const onRejection = (err: unknown) => rejections.push(err);
+    process.on("unhandledRejection", onRejection);
+    try {
+      const r = await runBashCommand("sleep 5", 100, undefined, process.cwd());
+      expect(r.timedOut).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  });
+
+  test("bounded drain returns even when a daemon escapes our process group", async () => {
+    // A child that calls setsid itself leaves our pgid and survives killGroup.
+    // If it keeps the pipe open, drain would block forever; the DRAIN_GRACE_MS
+    // bound forces us to return anyway. The marker lets us clean up after.
+    const marker = `pim-test-detached-${Date.now()}`;
+    const startedAt = Date.now();
+    const r = await runBashCommand(
+      `setsid bash -c 'sleep 60; echo ${marker}' > /tmp/${marker}.out 2>&1 < /dev/null & disown; echo done`,
+      5000,
+      undefined,
+      process.cwd()
+    );
+    const elapsed = Date.now() - startedAt;
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.text.trim()).toBe("done");
+    expect(elapsed).toBeLessThan(DRAIN_GRACE_MS + 2000);
+    try {
+      Bun.spawnSync({ cmd: ["pkill", "-f", marker] });
+      Bun.spawnSync({ cmd: ["rm", "-f", `/tmp/${marker}.out`] });
+    } catch {}
+  });
+
+  test("killAllActiveBashGroups sweeps in-flight subtrees", async () => {
+    const marker = `/tmp/pim-test-active-${Date.now()}.marker`;
+    // Long sleep that would touch a marker file if it ran to completion;
+    // a successful sweep kills the bash group before the touch can fire.
+    const pending = runBashCommand(
+      `sleep 30 && touch ${marker}`,
+      30_000,
+      undefined,
+      process.cwd()
+    );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    killAllActiveBashGroups("SIGTERM");
+    const result = await pending;
+    expect(result.exitCode === null || result.exitCode !== 0).toBe(true);
+    // Wait past the would-be sleep + kill grace; the marker should not exist
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(Bun.file(marker).size).toBe(0);
   });
 
   test("truncates very large stdout", async () => {

--- a/src/extensions/bash/run.test.ts
+++ b/src/extensions/bash/run.test.ts
@@ -81,7 +81,7 @@ describe("runBashCommand (integration)", () => {
     expect(r.exitCode === null || r.exitCode !== 0).toBe(true);
     expect(elapsed).toBeLessThan(KILL_GRACE_MS + 2000);
     // wait briefly for SIGKILL grace then confirm no stray sleep 41 remains
-    await new Promise((resolve) => setTimeout(resolve, KILL_GRACE_MS + 500));
+    await Bun.sleep(KILL_GRACE_MS + 500);
     const probe = Bun.spawnSync({ cmd: ["pgrep", "-f", marker] });
     expect(probe.exitCode).not.toBe(0);
   });
@@ -97,7 +97,7 @@ describe("runBashCommand (integration)", () => {
     try {
       const r = await runBashCommand("sleep 5", 100, undefined, process.cwd());
       expect(r.timedOut).toBe(true);
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await Bun.sleep(100);
       expect(rejections).toEqual([]);
     } finally {
       process.off("unhandledRejection", onRejection);
@@ -136,12 +136,12 @@ describe("runBashCommand (integration)", () => {
       undefined,
       process.cwd()
     );
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await Bun.sleep(200);
     killAllActiveBashGroups("SIGTERM");
     const result = await pending;
     expect(result.exitCode === null || result.exitCode !== 0).toBe(true);
     // Wait past the would-be sleep + kill grace; the marker should not exist
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await Bun.sleep(500);
     expect(Bun.file(marker).size).toBe(0);
   });
 

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -14,19 +14,14 @@ const activePids = new Set<number>();
  * signal handlers so a daemon that `setsid`s out of our group (or
  * harbor/parent SIGTERM) still tears down its bash subtree.
  */
-export function killAllActiveBashGroups(
-  sig: NodeJS.Signals = "SIGTERM"
-): void {
+export function killAllActiveBashGroups(sig: NodeJS.Signals = "SIGTERM"): void {
   for (const pid of activePids) {
     killGroup(pid, sig);
   }
   activePids.clear();
 }
 
-async function drain(
-  reader: Reader | null,
-  cap: StreamCapture
-): Promise<void> {
+async function drain(reader: Reader | null, cap: StreamCapture): Promise<void> {
   if (!reader) {
     return;
   }
@@ -183,7 +178,9 @@ export async function runBashCommand(
       signal.removeEventListener("abort", onAbort);
     }
     for (const reader of [stdoutReader, stderrReader]) {
-      if (!reader) continue;
+      if (!reader) {
+        continue;
+      }
       try {
         void reader.cancel().catch(() => {});
       } catch {}

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -1,14 +1,35 @@
 import { StreamCapture } from "./capture";
-import { type BashCommandResult, KILL_GRACE_MS } from "./schema";
+import {
+  type BashCommandResult,
+  DRAIN_GRACE_MS,
+  KILL_GRACE_MS,
+} from "./schema";
+
+type Reader = ReadableStreamDefaultReader<Uint8Array>;
+
+const activePids = new Set<number>();
+
+/**
+ * Signal every active bash process group. Called from extension-level
+ * signal handlers so a daemon that `setsid`s out of our group (or
+ * harbor/parent SIGTERM) still tears down its bash subtree.
+ */
+export function killAllActiveBashGroups(
+  sig: NodeJS.Signals = "SIGTERM"
+): void {
+  for (const pid of activePids) {
+    killGroup(pid, sig);
+  }
+  activePids.clear();
+}
 
 async function drain(
-  stream: ReadableStream<Uint8Array> | undefined,
+  reader: Reader | null,
   cap: StreamCapture
 ): Promise<void> {
-  if (!stream) {
+  if (!reader) {
     return;
   }
-  const reader = stream.getReader();
   try {
     while (true) {
       const { value, done } = await reader.read();
@@ -20,7 +41,7 @@ async function drain(
       }
     }
   } catch {
-    // stream cancelled; drop remaining bytes
+    // reader cancelled; drop remaining bytes
   } finally {
     try {
       reader.releaseLock();
@@ -41,6 +62,19 @@ function killGroup(pid: number | undefined, sig: NodeJS.Signals): void {
   }
 }
 
+function getReader(
+  stream: ReadableStream<Uint8Array> | undefined
+): Reader | null {
+  if (!stream) {
+    return null;
+  }
+  try {
+    return stream.getReader();
+  } catch {
+    return null;
+  }
+}
+
 export async function runBashCommand(
   command: string,
   timeoutMs: number,
@@ -51,7 +85,7 @@ export async function runBashCommand(
   const stdoutCap = new StreamCapture();
   const stderrCap = new StreamCapture();
 
-  // setsid puts bash and all descendants into a fresh process group with
+  // setsid puts bash and its descendants into a fresh process group with
   // pgid == proc.pid, so we can signal the whole tree on timeout/abort
   // instead of leaving backgrounded grandchildren alive holding our pipes.
   const proc = Bun.spawn({
@@ -61,16 +95,28 @@ export async function runBashCommand(
     stderr: "pipe",
     env: { ...process.env },
   });
+  if (proc.pid !== undefined) {
+    activePids.add(proc.pid);
+  }
 
   let timedOut = false;
   let aborted = false;
 
-  // Fire-and-forget drains: a backgrounded child can inherit the subshell's
-  // fds and keep the pipes open after bash exits, so we must not block on
-  // EOF. We race proc.exited against a wall-clock timeout instead, then
-  // cancel the streams to release the pipes.
-  void drain(proc.stdout as unknown as ReadableStream<Uint8Array>, stdoutCap);
-  void drain(proc.stderr as unknown as ReadableStream<Uint8Array>, stderrCap);
+  // We own the readers so we can force-cancel them later even while the
+  // background drains are still mid-read. Cancelling via the held reader
+  // does not throw the way ReadableStream.cancel() on a locked stream does.
+  const stdoutReader = getReader(
+    proc.stdout as unknown as ReadableStream<Uint8Array>
+  );
+  const stderrReader = getReader(
+    proc.stderr as unknown as ReadableStream<Uint8Array>
+  );
+
+  // Fire-and-forget drains. A backgrounded child can inherit the subshell's
+  // fds and keep the pipes open after bash exits, so we can't block on EOF;
+  // we race proc.exited against a wall-clock timeout instead.
+  const stdoutDrain = drain(stdoutReader, stdoutCap);
+  const stderrDrain = drain(stderrReader, stderrCap);
 
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   const exitedPromise = proc.exited.then(() => "exited" as const);
@@ -121,6 +167,14 @@ export async function runBashCommand(
 
     exitCode = proc.exitCode ?? null;
     signalCode = (proc.signalCode as NodeJS.Signals | null | undefined) ?? null;
+
+    // Bound the drain so a detached grandchild holding the pipe can't keep
+    // the drain promise + capture buffer alive past this call. After the
+    // grace, force-cancel via our held readers.
+    await Promise.race([
+      Promise.all([stdoutDrain, stderrDrain]),
+      new Promise<void>((r) => setTimeout(r, DRAIN_GRACE_MS)),
+    ]);
   } finally {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
@@ -128,10 +182,14 @@ export async function runBashCommand(
     if (signal) {
       signal.removeEventListener("abort", onAbort);
     }
-    for (const stream of [proc.stdout, proc.stderr]) {
+    for (const reader of [stdoutReader, stderrReader]) {
+      if (!reader) continue;
       try {
-        stream?.cancel();
+        void reader.cancel().catch(() => {});
       } catch {}
+    }
+    if (proc.pid !== undefined) {
+      activePids.delete(proc.pid);
     }
   }
 

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -157,7 +157,7 @@ export async function runBashCommand(
     // the drain promise + capture buffer alive past this call.
     await Promise.race([
       Promise.all([stdoutDrain, stderrDrain]),
-      new Promise<void>((r) => setTimeout(r, DRAIN_GRACE_MS)),
+      Bun.sleep(DRAIN_GRACE_MS),
     ]);
   } finally {
     if (timeoutHandle) {

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -57,14 +57,7 @@ function killGroup(pid: number | undefined, sig: NodeJS.Signals): void {
 function getReader(
   stream: ReadableStream<Uint8Array> | undefined
 ): Reader | null {
-  if (!stream) {
-    return null;
-  }
-  try {
-    return stream.getReader();
-  } catch {
-    return null;
-  }
+  return stream ? stream.getReader() : null;
 }
 
 export async function runBashCommand(

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -9,11 +9,8 @@ type Reader = ReadableStreamDefaultReader<Uint8Array>;
 
 const activePids = new Set<number>();
 
-/**
- * Signal every active bash process group. Called from extension-level
- * signal handlers so a daemon that `setsid`s out of our group (or
- * harbor/parent SIGTERM) still tears down its bash subtree.
- */
+// Wired into the extension's signal handlers so a daemon that `setsid`s
+// out of our group (or harbor/parent SIGTERM) still tears down its subtree.
 export function killAllActiveBashGroups(sig: NodeJS.Signals = "SIGTERM"): void {
   for (const pid of activePids) {
     killGroup(pid, sig);
@@ -164,8 +161,7 @@ export async function runBashCommand(
     signalCode = (proc.signalCode as NodeJS.Signals | null | undefined) ?? null;
 
     // Bound the drain so a detached grandchild holding the pipe can't keep
-    // the drain promise + capture buffer alive past this call. After the
-    // grace, force-cancel via our held readers.
+    // the drain promise + capture buffer alive past this call.
     await Promise.race([
       Promise.all([stdoutDrain, stderrDrain]),
       new Promise<void>((r) => setTimeout(r, DRAIN_GRACE_MS)),

--- a/src/extensions/bash/schema.ts
+++ b/src/extensions/bash/schema.ts
@@ -4,7 +4,7 @@ export const STREAM_HEAD_BYTES = 4096;
 export const STREAM_TAIL_BYTES = 4096;
 export const DEFAULT_TIMEOUT_MS = 30_000;
 export const KILL_GRACE_MS = 2000;
-export const DRAIN_GRACE_MS = 2000;
+export const DRAIN_GRACE_MS = 1000;
 
 export const bashSchema = Type.Object({
   command: Type.String({

--- a/src/extensions/bash/schema.ts
+++ b/src/extensions/bash/schema.ts
@@ -4,6 +4,7 @@ export const STREAM_HEAD_BYTES = 4096;
 export const STREAM_TAIL_BYTES = 4096;
 export const DEFAULT_TIMEOUT_MS = 30_000;
 export const KILL_GRACE_MS = 2000;
+export const DRAIN_GRACE_MS = 2000;
 
 export const bashSchema = Type.Object({
   command: Type.String({


### PR DESCRIPTION
## Summary

Four small fixes to the bash extension's shutdown / cleanup paths:

- **Locked-stream cancel**: skip `stream.cancel()` when a fire-and-forget drain still holds the reader. Cancel on a locked stream rejects with `ERR_INVALID_STATE` and the unhandled rejection crashes Bun even with the surrounding try/catch.
- **Bounded drain**: hold the readers ourselves, race the drains against `DRAIN_GRACE_MS`, then force-cancel via the held reader. Stops the drain promise + capture buffer from outliving the function when a detached grandchild keeps the pipe open.
- **Process-group sweep**: track active bash pids and install SIGTERM/SIGINT/SIGHUP handlers in the extension entrypoint to kill outstanding subtrees (including daemons that called `setsid` themselves and escaped our group) before re-raising the signal.
- **Launcher signal forwarding**: forward the same signals from `bin/pim.ts` to the pi subprocess so harness-initiated shutdowns reach the extension handler instead of orphaning bash trees.

Compared structurally against pi (`detached: true` + `killProcessTree` + tracked-pid Set), Codex (`setpgid` + `IO_DRAIN_TIMEOUT_MS` + `PR_SET_PDEATHSIG`), and opencode (`process.kill(-pid, ...)` with 200ms grace). The bounded-drain and pid-tracking patterns come from there.

## Test plan

- [x] `bun test src/extensions/bash/run.test.ts` — 11/11 pass
- [x] Added regression test: `stream.cancel()` on locked stream does not leak unhandled rejection
- [x] Added regression test: bounded drain returns within `DRAIN_GRACE_MS + 2s` even when a `setsid`-detached grandchild holds the pipe
- [x] Added regression test: `killAllActiveBashGroups` SIGTERMs in-flight subtrees (verified via marker-file negative-presence)