### PR TITLE
feat(bash): spill full output to /tmp when truncated

### DIFF
--- a/src/extensions/bash/capture.test.ts
+++ b/src/extensions/bash/capture.test.ts
@@ -19,7 +19,12 @@ describe("concat", () => {
 describe("StreamCapture", () => {
   test("empty capture", () => {
     const c = new StreamCapture();
-    expect(c.snapshot()).toEqual({ text: "", totalBytes: 0, truncated: false });
+    expect(c.snapshot()).toEqual({
+      text: "",
+      totalBytes: 0,
+      truncated: false,
+      path: null,
+    });
   });
 
   test("ignores zero-byte chunks", () => {
@@ -30,6 +35,7 @@ describe("StreamCapture", () => {
       text: "hi",
       totalBytes: 2,
       truncated: false,
+      path: null,
     });
   });
 
@@ -41,6 +47,7 @@ describe("StreamCapture", () => {
       text: "hello world",
       totalBytes: 11,
       truncated: false,
+      path: null,
     });
   });
 

--- a/src/extensions/bash/capture.test.ts
+++ b/src/extensions/bash/capture.test.ts
@@ -74,7 +74,7 @@ describe("StreamCapture", () => {
     expect(snap.text).toContain(`... ${500} bytes truncated ...`);
   });
 
-  test("drops middle chunks as they arrive (bounded memory)", () => {
+  test("keeps head and final tail when many middle chunks arrive", () => {
     const c = new StreamCapture();
     const HEAD_FILL = "A".repeat(STREAM_HEAD_BYTES);
     c.push(u8(HEAD_FILL));

--- a/src/extensions/bash/capture.ts
+++ b/src/extensions/bash/capture.ts
@@ -15,48 +15,27 @@ export function concat(parts: Uint8Array[], total: number): Uint8Array {
 }
 
 export class StreamCapture {
-  private head: Uint8Array[] = [];
-  private headBytes = 0;
-  private tail: Uint8Array[] = [];
-  private tailBytes = 0;
+  private chunks: Uint8Array[] = [];
   private totalBytesAccum = 0;
 
   push(chunk: Uint8Array): void {
     if (chunk.byteLength === 0) {
       return;
     }
+    this.chunks.push(chunk);
     this.totalBytesAccum += chunk.byteLength;
-
-    if (this.headBytes < STREAM_HEAD_BYTES) {
-      const need = STREAM_HEAD_BYTES - this.headBytes;
-      if (chunk.byteLength <= need) {
-        this.head.push(chunk);
-        this.headBytes += chunk.byteLength;
-        return;
-      }
-      this.head.push(chunk.subarray(0, need));
-      this.headBytes += need;
-      chunk = chunk.subarray(need);
-    }
-
-    this.tail.push(chunk);
-    this.tailBytes += chunk.byteLength;
-
-    while (this.tail.length > 0 && this.tailBytes > STREAM_TAIL_BYTES) {
-      const first = this.tail[0]!;
-      if (this.tailBytes - first.byteLength >= STREAM_TAIL_BYTES) {
-        this.tail.shift();
-        this.tailBytes -= first.byteLength;
-      } else {
-        const drop = this.tailBytes - STREAM_TAIL_BYTES;
-        this.tail[0] = first.subarray(drop);
-        this.tailBytes -= drop;
-      }
-    }
   }
 
   get totalBytes(): number {
     return this.totalBytesAccum;
+  }
+
+  get truncated(): boolean {
+    return this.totalBytesAccum > STREAM_HEAD_BYTES + STREAM_TAIL_BYTES;
+  }
+
+  full(): Uint8Array {
+    return concat(this.chunks, this.totalBytesAccum);
   }
 
   snapshot(): CapturedStream {
@@ -64,21 +43,19 @@ export class StreamCapture {
       return { text: "", totalBytes: 0, truncated: false };
     }
     const dec = new TextDecoder();
-    const truncated = this.totalBytesAccum > this.headBytes + this.tailBytes;
-    if (!truncated) {
-      const all = concat(
-        [...this.head, ...this.tail],
-        this.headBytes + this.tailBytes
-      );
+    if (!this.truncated) {
       return {
-        text: dec.decode(all),
+        text: dec.decode(this.full()),
         totalBytes: this.totalBytesAccum,
         truncated: false,
       };
     }
-    const headText = dec.decode(concat(this.head, this.headBytes));
-    const tailText = dec.decode(concat(this.tail, this.tailBytes));
-    const middle = this.totalBytesAccum - this.headBytes - this.tailBytes;
+    const all = this.full();
+    const headText = dec.decode(all.subarray(0, STREAM_HEAD_BYTES));
+    const tailText = dec.decode(
+      all.subarray(all.byteLength - STREAM_TAIL_BYTES)
+    );
+    const middle = this.totalBytesAccum - STREAM_HEAD_BYTES - STREAM_TAIL_BYTES;
     return {
       text: `${headText}\n... ${middle} bytes truncated ...\n${tailText}`,
       totalBytes: this.totalBytesAccum,

--- a/src/extensions/bash/capture.ts
+++ b/src/extensions/bash/capture.ts
@@ -17,6 +17,7 @@ export function concat(parts: Uint8Array[], total: number): Uint8Array {
 export class StreamCapture {
   private chunks: Uint8Array[] = [];
   private totalBytesAccum = 0;
+  private fullBytes: Uint8Array | null = null;
 
   push(chunk: Uint8Array): void {
     if (chunk.byteLength === 0) {
@@ -35,12 +36,15 @@ export class StreamCapture {
   }
 
   full(): Uint8Array {
-    return concat(this.chunks, this.totalBytesAccum);
+    if (!this.fullBytes) {
+      this.fullBytes = concat(this.chunks, this.totalBytesAccum);
+    }
+    return this.fullBytes;
   }
 
   snapshot(): CapturedStream {
     if (this.totalBytesAccum === 0) {
-      return { text: "", totalBytes: 0, truncated: false };
+      return { text: "", totalBytes: 0, truncated: false, path: null };
     }
     const dec = new TextDecoder();
     if (!this.truncated) {
@@ -48,6 +52,7 @@ export class StreamCapture {
         text: dec.decode(this.full()),
         totalBytes: this.totalBytesAccum,
         truncated: false,
+        path: null,
       };
     }
     const all = this.full();
@@ -60,6 +65,7 @@ export class StreamCapture {
       text: `${headText}\n... ${middle} bytes truncated ...\n${tailText}`,
       totalBytes: this.totalBytesAccum,
       truncated: true,
+      path: null,
     };
   }
 }

--- a/src/extensions/bash/format.test.ts
+++ b/src/extensions/bash/format.test.ts
@@ -20,6 +20,8 @@ function makeResult(
     signal: null,
     stdout: { text: "", totalBytes: 0, truncated: false },
     stderr: { text: "", totalBytes: 0, truncated: false },
+    stdoutPath: null,
+    stderrPath: null,
     timedOut: false,
     aborted: false,
     durationMs: 1,
@@ -41,11 +43,15 @@ describe("stripTrailingNewline", () => {
 
 describe("formatTruncationAffordance", () => {
   test("emits bracketed affordance with byte counts and next-step", () => {
-    const out = formatTruncationAffordance("stderr", {
-      text: "x",
-      totalBytes: 12345,
-      truncated: true,
-    });
+    const out = formatTruncationAffordance(
+      "stderr",
+      {
+        text: "x",
+        totalBytes: 12345,
+        truncated: true,
+      },
+      null
+    );
     expect(out.startsWith("[bash tool:")).toBe(true);
     expect(out.endsWith("]")).toBe(true);
     expect(out).toContain("stderr truncated");
@@ -54,6 +60,17 @@ describe("formatTruncationAffordance", () => {
     expect(out).toContain("of 12345");
     expect(out).toContain("redirect to a file");
     expect(out).toContain("read");
+  });
+
+  test("points to spill path when one is provided", () => {
+    const out = formatTruncationAffordance(
+      "stdout",
+      { text: "x", totalBytes: 99999, truncated: true },
+      "/tmp/pim-bash-abc.out"
+    );
+    expect(out).toContain("/tmp/pim-bash-abc.out");
+    expect(out).toContain("full output saved");
+    expect(out).not.toContain("redirect to a file");
   });
 });
 
@@ -145,8 +162,8 @@ describe("detailsOf", () => {
       durationMs: 42,
       timedOut: false,
       aborted: false,
-      stdout: { totalBytes: 99999, truncated: true },
-      stderr: { totalBytes: 5, truncated: false },
+      stdout: { totalBytes: 99999, truncated: true, path: null },
+      stderr: { totalBytes: 5, truncated: false, path: null },
     });
   });
 });

--- a/src/extensions/bash/format.test.ts
+++ b/src/extensions/bash/format.test.ts
@@ -18,10 +18,8 @@ function makeResult(
   return {
     exitCode: 0,
     signal: null,
-    stdout: { text: "", totalBytes: 0, truncated: false },
-    stderr: { text: "", totalBytes: 0, truncated: false },
-    stdoutPath: null,
-    stderrPath: null,
+    stdout: { text: "", totalBytes: 0, truncated: false, path: null },
+    stderr: { text: "", totalBytes: 0, truncated: false, path: null },
     timedOut: false,
     aborted: false,
     durationMs: 1,
@@ -43,15 +41,12 @@ describe("stripTrailingNewline", () => {
 
 describe("formatTruncationAffordance", () => {
   test("emits bracketed affordance with byte counts and next-step", () => {
-    const out = formatTruncationAffordance(
-      "stderr",
-      {
-        text: "x",
-        totalBytes: 12345,
-        truncated: true,
-      },
-      null
-    );
+    const out = formatTruncationAffordance("stderr", {
+      text: "x",
+      totalBytes: 12345,
+      truncated: true,
+      path: null,
+    });
     expect(out.startsWith("[bash tool:")).toBe(true);
     expect(out.endsWith("]")).toBe(true);
     expect(out).toContain("stderr truncated");
@@ -63,11 +58,12 @@ describe("formatTruncationAffordance", () => {
   });
 
   test("points to spill path when one is provided", () => {
-    const out = formatTruncationAffordance(
-      "stdout",
-      { text: "x", totalBytes: 99999, truncated: true },
-      "/tmp/pim-bash-abc.out"
-    );
+    const out = formatTruncationAffordance("stdout", {
+      text: "x",
+      totalBytes: 99999,
+      truncated: true,
+      path: "/tmp/pim-bash-abc.out",
+    });
     expect(out).toContain("/tmp/pim-bash-abc.out");
     expect(out).toContain("full output saved");
     expect(out).not.toContain("redirect to a file");
@@ -78,7 +74,12 @@ describe("formatResult", () => {
   test("happy path with stdout only", () => {
     const out = formatResult(
       makeResult({
-        stdout: { text: "hello\n", totalBytes: 6, truncated: false },
+        stdout: {
+          text: "hello\n",
+          totalBytes: 6,
+          truncated: false,
+          path: null,
+        },
       }),
       30_000
     );
@@ -112,8 +113,8 @@ describe("formatResult", () => {
     const out = formatResult(
       makeResult({
         exitCode: 1,
-        stdout: { text: "out", totalBytes: 3, truncated: false },
-        stderr: { text: "err", totalBytes: 3, truncated: false },
+        stdout: { text: "out", totalBytes: 3, truncated: false, path: null },
+        stderr: { text: "err", totalBytes: 3, truncated: false, path: null },
       }),
       30_000
     );
@@ -123,7 +124,12 @@ describe("formatResult", () => {
   test("appends bracket affordance after a truncated stream body", () => {
     const out = formatResult(
       makeResult({
-        stdout: { text: "head…tail", totalBytes: 99999, truncated: true },
+        stdout: {
+          text: "head…tail",
+          totalBytes: 99999,
+          truncated: true,
+          path: null,
+        },
       }),
       30_000
     );
@@ -138,7 +144,7 @@ describe("formatResult", () => {
   test("does not append affordance when stream is not truncated", () => {
     const out = formatResult(
       makeResult({
-        stdout: { text: "ok", totalBytes: 2, truncated: false },
+        stdout: { text: "ok", totalBytes: 2, truncated: false, path: null },
       }),
       30_000
     );
@@ -152,8 +158,8 @@ describe("detailsOf", () => {
       makeResult({
         exitCode: 1,
         durationMs: 42,
-        stdout: { text: "x", totalBytes: 99999, truncated: true },
-        stderr: { text: "y", totalBytes: 5, truncated: false },
+        stdout: { text: "x", totalBytes: 99999, truncated: true, path: null },
+        stderr: { text: "y", totalBytes: 5, truncated: false, path: null },
       })
     );
     expect(details).toEqual({

--- a/src/extensions/bash/format.ts
+++ b/src/extensions/bash/format.ts
@@ -12,9 +12,14 @@ export function stripTrailingNewline(s: string): string {
 
 export function formatTruncationAffordance(
   label: string,
-  s: CapturedStream
+  s: CapturedStream,
+  spillPath: string | null
 ): string {
-  return `[bash tool: ${label} truncated — kept first ${STREAM_HEAD_BYTES} bytes + last ${STREAM_TAIL_BYTES} bytes of ${s.totalBytes}; redirect to a file (e.g. \`cmd > /tmp/out.log\`) and use read for the full output.]`;
+  const base = `[bash tool: ${label} truncated — kept first ${STREAM_HEAD_BYTES} bytes + last ${STREAM_TAIL_BYTES} bytes of ${s.totalBytes}`;
+  if (spillPath) {
+    return `${base}; full output saved to ${spillPath} — use read for the middle bytes.]`;
+  }
+  return `${base}; redirect to a file (e.g. \`cmd > /tmp/out.log\`) and use read for the full output.]`;
 }
 
 export function formatResult(
@@ -34,14 +39,18 @@ export function formatResult(
     lines.push("stdout:");
     lines.push(stripTrailingNewline(result.stdout.text));
     if (result.stdout.truncated) {
-      lines.push(formatTruncationAffordance("stdout", result.stdout));
+      lines.push(
+        formatTruncationAffordance("stdout", result.stdout, result.stdoutPath)
+      );
     }
   }
   if (result.stderr.totalBytes > 0) {
     lines.push("stderr:");
     lines.push(stripTrailingNewline(result.stderr.text));
     if (result.stderr.truncated) {
-      lines.push(formatTruncationAffordance("stderr", result.stderr));
+      lines.push(
+        formatTruncationAffordance("stderr", result.stderr, result.stderrPath)
+      );
     }
   }
   return lines.join("\n");
@@ -61,10 +70,12 @@ export function detailsOf(result: BashCommandResult): BashDetails {
     stdout: {
       totalBytes: result.stdout.totalBytes,
       truncated: result.stdout.truncated,
+      path: result.stdoutPath,
     },
     stderr: {
       totalBytes: result.stderr.totalBytes,
       truncated: result.stderr.truncated,
+      path: result.stderrPath,
     },
   };
 }

--- a/src/extensions/bash/format.ts
+++ b/src/extensions/bash/format.ts
@@ -12,12 +12,11 @@ export function stripTrailingNewline(s: string): string {
 
 export function formatTruncationAffordance(
   label: string,
-  s: CapturedStream,
-  spillPath: string | null
+  s: CapturedStream
 ): string {
   const base = `[bash tool: ${label} truncated — kept first ${STREAM_HEAD_BYTES} bytes + last ${STREAM_TAIL_BYTES} bytes of ${s.totalBytes}`;
-  if (spillPath) {
-    return `${base}; full output saved to ${spillPath} — use read for the middle bytes.]`;
+  if (s.path) {
+    return `${base}; full output saved to ${s.path} — use read for the middle bytes.]`;
   }
   return `${base}; redirect to a file (e.g. \`cmd > /tmp/out.log\`) and use read for the full output.]`;
 }
@@ -39,18 +38,14 @@ export function formatResult(
     lines.push("stdout:");
     lines.push(stripTrailingNewline(result.stdout.text));
     if (result.stdout.truncated) {
-      lines.push(
-        formatTruncationAffordance("stdout", result.stdout, result.stdoutPath)
-      );
+      lines.push(formatTruncationAffordance("stdout", result.stdout));
     }
   }
   if (result.stderr.totalBytes > 0) {
     lines.push("stderr:");
     lines.push(stripTrailingNewline(result.stderr.text));
     if (result.stderr.truncated) {
-      lines.push(
-        formatTruncationAffordance("stderr", result.stderr, result.stderrPath)
-      );
+      lines.push(formatTruncationAffordance("stderr", result.stderr));
     }
   }
   return lines.join("\n");
@@ -70,12 +65,12 @@ export function detailsOf(result: BashCommandResult): BashDetails {
     stdout: {
       totalBytes: result.stdout.totalBytes,
       truncated: result.stdout.truncated,
-      path: result.stdoutPath,
+      path: result.stdout.path,
     },
     stderr: {
       totalBytes: result.stderr.totalBytes,
       truncated: result.stderr.truncated,
-      path: result.stderrPath,
+      path: result.stderr.path,
     },
   };
 }

--- a/src/extensions/bash/index.ts
+++ b/src/extensions/bash/index.ts
@@ -2,7 +2,11 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Renderer } from "../../shared/Renderer";
 import { Tools } from "../../shared/Tools";
 import { detailsOf, formatResult, isErrorResult } from "./format";
-import { killAllActiveBashGroups, runBashCommand } from "./run";
+import {
+  cleanupSpillFiles,
+  killAllActiveBashGroups,
+  runBashCommand,
+} from "./run";
 import {
   type BashInput,
   bashSchema,
@@ -30,6 +34,9 @@ function installShutdownHandlers(): void {
     process.once(sig, () => {
       try {
         killAllActiveBashGroups(sig);
+      } catch {}
+      try {
+        cleanupSpillFiles();
       } catch {}
       process.kill(process.pid, sig);
     });

--- a/src/extensions/bash/index.ts
+++ b/src/extensions/bash/index.ts
@@ -11,6 +11,8 @@ import {
   STREAM_TAIL_BYTES,
 } from "./schema";
 
+const DEFAULT_TIMEOUT_SEC = DEFAULT_TIMEOUT_MS / 1000;
+
 const PREVIEW_LINES = 5;
 
 let signalHandlersInstalled = false;
@@ -42,6 +44,7 @@ export default function (pi: ExtensionAPI): void {
     description:
       `Execute a bash command in the cwd. ` +
       `Returns exit code, signal (if any), and stdout/stderr captured separately. ` +
+      `Default timeout is ${DEFAULT_TIMEOUT_SEC}s — pass timeoutMs to raise it for long-running commands (builds, tests, training, installs). ` +
       `Each stream is capped at ${STREAM_HEAD_BYTES} bytes head + ${STREAM_TAIL_BYTES} bytes tail; the middle is truncated. ` +
       `Use bash with trimming args or pipe to head/tail/cut to keep output small.`,
     parameters: bashSchema,

--- a/src/extensions/bash/run.test.ts
+++ b/src/extensions/bash/run.test.ts
@@ -167,21 +167,26 @@ describe("runBashCommand (integration)", () => {
       undefined,
       process.cwd()
     );
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout.truncated).toBe(true);
-    expect(r.stdoutPath).toBeTruthy();
-    const spilled = await Bun.file(r.stdoutPath!).text();
-    expect(spilled.length).toBe(totalBytes);
-    expect(spilled).toBe("A".repeat(totalBytes));
     try {
-      Bun.spawnSync({ cmd: ["rm", "-f", r.stdoutPath!] });
-    } catch {}
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.truncated).toBe(true);
+      expect(r.stdout.path).toBeTruthy();
+      const spilled = await Bun.file(r.stdout.path!).text();
+      expect(spilled.length).toBe(totalBytes);
+      expect(spilled).toBe("A".repeat(totalBytes));
+    } finally {
+      if (r.stdout.path) {
+        try {
+          Bun.spawnSync({ cmd: ["rm", "-f", r.stdout.path] });
+        } catch {}
+      }
+    }
   });
 
   test("omits spill path when stream is empty", async () => {
     const r = await runBashCommand("true", 5000, undefined, process.cwd());
     expect(r.exitCode).toBe(0);
-    expect(r.stdoutPath).toBeNull();
-    expect(r.stderrPath).toBeNull();
+    expect(r.stdout.path).toBeNull();
+    expect(r.stderr.path).toBeNull();
   });
 });

--- a/src/extensions/bash/run.test.ts
+++ b/src/extensions/bash/run.test.ts
@@ -158,4 +158,30 @@ describe("runBashCommand (integration)", () => {
     expect(r.stdout.truncated).toBe(true);
     expect(r.stdout.text).toContain("bytes truncated");
   });
+
+  test("spills full stdout to a temp file when truncated", async () => {
+    const totalBytes = STREAM_HEAD_BYTES + STREAM_TAIL_BYTES + 4096;
+    const r = await runBashCommand(
+      `head -c ${totalBytes} /dev/zero | tr '\\0' 'A'`,
+      5000,
+      undefined,
+      process.cwd()
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.truncated).toBe(true);
+    expect(r.stdoutPath).toBeTruthy();
+    const spilled = await Bun.file(r.stdoutPath!).text();
+    expect(spilled.length).toBe(totalBytes);
+    expect(spilled).toBe("A".repeat(totalBytes));
+    try {
+      Bun.spawnSync({ cmd: ["rm", "-f", r.stdoutPath!] });
+    } catch {}
+  });
+
+  test("omits spill path when stream is empty", async () => {
+    const r = await runBashCommand("true", 5000, undefined, process.cwd());
+    expect(r.exitCode).toBe(0);
+    expect(r.stdoutPath).toBeNull();
+    expect(r.stderrPath).toBeNull();
+  });
 });

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { StreamCapture } from "./capture";
@@ -11,6 +12,7 @@ import {
 type Reader = ReadableStreamDefaultReader<Uint8Array>;
 
 const activePids = new Set<number>();
+const spillPaths = new Set<string>();
 
 // Wired into the extension's signal handlers so a daemon that `setsid`s
 // out of our group (or harbor/parent SIGTERM) still tears down its subtree.
@@ -19,6 +21,17 @@ export function killAllActiveBashGroups(sig: NodeJS.Signals = "SIGTERM"): void {
     killGroup(pid, sig);
   }
   activePids.clear();
+}
+
+// /tmp is tmpfs on most hosts; without an explicit sweep, spill files
+// accumulate in RAM for the lifetime of the pim session.
+export function cleanupSpillFiles(): void {
+  for (const path of spillPaths) {
+    try {
+      unlinkSync(path);
+    } catch {}
+  }
+  spillPaths.clear();
 }
 
 async function drain(reader: Reader | null, cap: StreamCapture): Promise<void> {
@@ -46,13 +59,15 @@ async function drain(reader: Reader | null, cap: StreamCapture): Promise<void> {
 
 async function spillIfTruncated(
   cap: StreamCapture,
-  path: string
+  suffix: ".out" | ".err"
 ): Promise<string | null> {
   if (!cap.truncated) {
     return null;
   }
+  const path = join(tmpdir(), `pim-bash-${randomUUID()}${suffix}`);
   try {
     await Bun.write(path, cap.full());
+    spillPaths.add(path);
     return path;
   } catch {
     return null;
@@ -87,9 +102,6 @@ export async function runBashCommand(
   const startedAt = Date.now();
   const stdoutCap = new StreamCapture();
   const stderrCap = new StreamCapture();
-  const callId = randomUUID();
-  const stdoutPath = join(tmpdir(), `pim-bash-${callId}.out`);
-  const stderrPath = join(tmpdir(), `pim-bash-${callId}.err`);
 
   // setsid puts bash and its descendants into a fresh process group with
   // pgid == proc.pid, so we can signal the whole tree on timeout/abort
@@ -200,18 +212,16 @@ export async function runBashCommand(
     }
   }
 
-  const [resolvedStdoutPath, resolvedStderrPath] = await Promise.all([
-    spillIfTruncated(stdoutCap, stdoutPath),
-    spillIfTruncated(stderrCap, stderrPath),
+  const [stdoutPath, stderrPath] = await Promise.all([
+    spillIfTruncated(stdoutCap, ".out"),
+    spillIfTruncated(stderrCap, ".err"),
   ]);
 
   return {
     exitCode,
     signal: signalCode,
-    stdout: stdoutCap.snapshot(),
-    stderr: stderrCap.snapshot(),
-    stdoutPath: resolvedStdoutPath,
-    stderrPath: resolvedStderrPath,
+    stdout: { ...stdoutCap.snapshot(), path: stdoutPath },
+    stderr: { ...stderrCap.snapshot(), path: stderrPath },
     timedOut,
     aborted,
     durationMs: Date.now() - startedAt,

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { StreamCapture } from "./capture";
 import {
   type BashCommandResult,
@@ -41,6 +44,24 @@ async function drain(reader: Reader | null, cap: StreamCapture): Promise<void> {
   }
 }
 
+// Match pi's approach: only spend a tmpfs file when the in-memory capture
+// actually had to drop the middle; small/non-truncated outputs leave nothing
+// behind. The model only ever needs the file when there's middle to recover.
+async function spillIfTruncated(
+  cap: StreamCapture,
+  path: string
+): Promise<string | null> {
+  if (!cap.truncated) {
+    return null;
+  }
+  try {
+    await Bun.write(path, cap.full());
+    return path;
+  } catch {
+    return null;
+  }
+}
+
 function killGroup(pid: number | undefined, sig: NodeJS.Signals): void {
   if (pid === undefined) {
     return;
@@ -69,6 +90,9 @@ export async function runBashCommand(
   const startedAt = Date.now();
   const stdoutCap = new StreamCapture();
   const stderrCap = new StreamCapture();
+  const callId = randomUUID();
+  const stdoutPath = join(tmpdir(), `pim-bash-${callId}.out`);
+  const stderrPath = join(tmpdir(), `pim-bash-${callId}.err`);
 
   // setsid puts bash and its descendants into a fresh process group with
   // pgid == proc.pid, so we can signal the whole tree on timeout/abort
@@ -179,11 +203,18 @@ export async function runBashCommand(
     }
   }
 
+  const [resolvedStdoutPath, resolvedStderrPath] = await Promise.all([
+    spillIfTruncated(stdoutCap, stdoutPath),
+    spillIfTruncated(stderrCap, stderrPath),
+  ]);
+
   return {
     exitCode,
     signal: signalCode,
     stdout: stdoutCap.snapshot(),
     stderr: stderrCap.snapshot(),
+    stdoutPath: resolvedStdoutPath,
+    stderrPath: resolvedStderrPath,
     timedOut,
     aborted,
     durationMs: Date.now() - startedAt,

--- a/src/extensions/bash/run.ts
+++ b/src/extensions/bash/run.ts
@@ -44,9 +44,6 @@ async function drain(reader: Reader | null, cap: StreamCapture): Promise<void> {
   }
 }
 
-// Match pi's approach: only spend a tmpfs file when the in-memory capture
-// actually had to drop the middle; small/non-truncated outputs leave nothing
-// behind. The model only ever needs the file when there's middle to recover.
 async function spillIfTruncated(
   cap: StreamCapture,
   path: string

--- a/src/extensions/bash/schema.ts
+++ b/src/extensions/bash/schema.ts
@@ -13,7 +13,7 @@ export const bashSchema = Type.Object({
   timeoutMs: Type.Optional(
     Type.Integer({
       minimum: 1,
-      description: `Timeout in milliseconds. Default is ${DEFAULT_TIMEOUT_MS} (${DEFAULT_TIMEOUT_MS / 1000}s) — raise it for long-running commands like builds, test suites, training runs, or installs. After timeout the process gets a ${KILL_GRACE_MS / 1000}s grace period before SIGKILL.`,
+      description: `Timeout in milliseconds. Default is ${DEFAULT_TIMEOUT_MS} (${DEFAULT_TIMEOUT_MS / 1000}s) — raise it for long-running commands like builds, test suites, training runs, or installs.`,
     })
   ),
 });

--- a/src/extensions/bash/schema.ts
+++ b/src/extensions/bash/schema.ts
@@ -23,6 +23,7 @@ export type CapturedStream = {
   readonly text: string;
   readonly totalBytes: number;
   readonly truncated: boolean;
+  readonly path: string | null;
 };
 
 export type BashCommandResult = {
@@ -30,8 +31,6 @@ export type BashCommandResult = {
   readonly signal: NodeJS.Signals | null;
   readonly stdout: CapturedStream;
   readonly stderr: CapturedStream;
-  readonly stdoutPath: string | null;
-  readonly stderrPath: string | null;
   readonly timedOut: boolean;
   readonly aborted: boolean;
   readonly durationMs: number;

--- a/src/extensions/bash/schema.ts
+++ b/src/extensions/bash/schema.ts
@@ -1,7 +1,7 @@
 import { type Static, Type } from "typebox";
 
-export const STREAM_HEAD_BYTES = 4096;
-export const STREAM_TAIL_BYTES = 4096;
+export const STREAM_HEAD_BYTES = 8192;
+export const STREAM_TAIL_BYTES = 8192;
 export const DEFAULT_TIMEOUT_MS = 30_000;
 export const KILL_GRACE_MS = 2000;
 export const DRAIN_GRACE_MS = 1000;
@@ -30,6 +30,8 @@ export type BashCommandResult = {
   readonly signal: NodeJS.Signals | null;
   readonly stdout: CapturedStream;
   readonly stderr: CapturedStream;
+  readonly stdoutPath: string | null;
+  readonly stderrPath: string | null;
   readonly timedOut: boolean;
   readonly aborted: boolean;
   readonly durationMs: number;
@@ -38,6 +40,7 @@ export type BashCommandResult = {
 export type BashStreamDetails = {
   readonly totalBytes: number;
   readonly truncated: boolean;
+  readonly path: string | null;
 };
 
 export type BashDetails = {

--- a/src/extensions/bash/schema.ts
+++ b/src/extensions/bash/schema.ts
@@ -13,7 +13,7 @@ export const bashSchema = Type.Object({
   timeoutMs: Type.Optional(
     Type.Integer({
       minimum: 1,
-      description: `Timeout in milliseconds (default ${DEFAULT_TIMEOUT_MS}). After timeout the process gets a ${KILL_GRACE_MS / 1000}s grace period before SIGKILL.`,
+      description: `Timeout in milliseconds. Default is ${DEFAULT_TIMEOUT_MS} (${DEFAULT_TIMEOUT_MS / 1000}s) — raise it for long-running commands like builds, test suites, training runs, or installs. After timeout the process gets a ${KILL_GRACE_MS / 1000}s grace period before SIGKILL.`,
     })
   ),
 });


### PR DESCRIPTION
## Summary

- Raise bash stream caps from 4K+4K to 8K+8K head/tail bytes.
- When a stream is truncated, write the full captured buffer to `/tmp/pim-bash-<uuid>.{out,err}` and point the model at it in the truncation affordance so `read` can recover the middle bytes.
- `StreamCapture` now holds all chunks instead of discarding the middle in-stream, matching pi's approach. Memory peak is command output size rather than head+tail; no file is written for small/non-truncated calls.

## Test plan

- [x] `bun run check` passes (374 tests, lint, typecheck, format)
- [x] New `spillIfTruncated` regression: truncated stream produces a file with the exact full content
- [x] Empty / non-truncated streams leave no file behind
- [x] Truncation affordance message mentions the spill path when present