### PR TITLE
feat(benchmarks): add Terminal-Bench 2.0 adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bun.lock
 dist/
 notes/
 vendor/
+__pycache__/
+benchmarks/*/runs/

--- a/benchmarks/terminal_bench_2/.env.example
+++ b/benchmarks/terminal_bench_2/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env and fill in. Pass to harbor with `--env-file <path>` or
+# export in your shell before running `./run.sh`.
+
+# Hosted-model providers (optional, only if --model targets them)
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+
+# Web tools
+EXA_API_KEY=
+JINA_API_KEY=
+
+# Local model server stubs (pi requires a non-empty value even for local)
+LLAMACPP_API_KEY=noop
+OLLAMA_API_KEY=noop

--- a/benchmarks/terminal_bench_2/README.md
+++ b/benchmarks/terminal_bench_2/README.md
@@ -1,0 +1,84 @@
+# Pim Agent · Terminal-Bench 2.0
+
+Run [Pim Agent](https://github.com/AaronCQL/pim-agent) on [Terminal-Bench 2.0](https://www.tbench.ai/leaderboard/terminal-bench/2.0) via [Harbor](https://www.harborframework.com) as an installed-agent (`BaseInstalledAgent`). Pim's source is bind-mounted into each task container; all of Pim's tools (Read/Write/Edit/Bash/Glob/Grep/WebFetch/WebSearch) run natively in-container against the task workspace.
+
+## Quick Start
+
+```bash
+# Single-task smoke (fast)
+TB_TASK=hello-world ./benchmarks/terminal_bench_2/run.sh
+
+# Full run, default model + output dir
+./benchmarks/terminal_bench_2/run.sh
+
+# Custom output dir + parallel
+./benchmarks/terminal_bench_2/run.sh /tmp/tb2-runs
+TB_N_CONCURRENT=4 ./benchmarks/terminal_bench_2/run.sh
+```
+
+Prerequisites:
+
+- Docker running
+- `harbor` installed (`pip install harbor` or `uv tool install harbor`)
+- `~/.pi/agent/models.json` configured with at least one provider+model. `run.sh` parses this to derive the default model and to pin the model-server hostname into the container via `extra_hosts`.
+- Model server reachable from this host (incl. Tailscale resolution if applicable). `run.sh` resolves the hostname with `getent hosts` and injects the IP into the overlay.
+- Required env vars exported on the host (see [`.env.example`](./.env.example)) — pass with `--env-file` if preferred
+
+## Architecture
+
+```
+run.sh
+  ├── reads ~/.pi/agent/models.json, picks first provider+model
+  ├── resolves model-server hostname (Tailscale or LAN) to IP
+  ├── exports PIM_REPO_ROOT, TB_LLM_HOST, TB_LLM_HOST_IP
+  └── harbor run --extra-docker-compose overlay.yaml --agent-import-path ...
+       │
+       ↓
+overlay.yaml          → extra_hosts: pin LLM host to its IP
+                      → volumes:     bind-mount $PIM_REPO_ROOT → /opt/pim:ro
+       │
+       ↓
+PimAgent.install()    → exec_as_root: apt deps + /logs/agent
+                      → exec_as_agent: install Bun, install pi globally
+                      → exec_as_agent: write ~/.pi/agent/models.json from host
+PimAgent.run()        → exec_as_agent: bun /opt/pim/bin/pim.ts --print --mode json ...
+                      → tee /logs/agent/pim.txt
+PimAgent.populate_context_post_run()
+                      → parse pim.txt for usage → context.{n_input,n_output,n_cache_tokens,cost_usd}
+```
+
+Files:
+
+| File | Role |
+| --- | --- |
+| `adapter.py` | `BaseInstalledAgent` subclass. Handles install, run, JSONL parsing. |
+| `overlay.yaml` | docker-compose overlay: `extra_hosts` for host gateway + bind mount `${PIM_REPO_ROOT}` → `/opt/pim`. |
+| `run.sh` | Wrapper around `harbor run` with the right flags. Exports `PIM_REPO_ROOT`. |
+| `.env.example` | Documents required host env vars (Anthropic / Exa / Jina / local model stubs). |
+
+## Configuration
+
+| Env var | Default | Effect |
+| --- | --- | --- |
+| `TB_PIM_MODEL` | `llamacpp/qwen3.6-35b-a3b` | Model spec passed to pim |
+| `TB_N_CONCURRENT` | `1` | Parallel task containers |
+| `TB_TASK` | _(unset)_ | Run a single named task instead of the full dataset |
+| `PIM_REPO_ROOT` | `<repo root>` | Path bind-mounted at `/opt/pim` (set by `run.sh`) |
+
+## Smoke test
+
+Before a full run, validate the pipeline with a single easy task:
+
+```bash
+TB_TASK=hello-world ./benchmarks/terminal_bench_2/run.sh /tmp/pim-smoke
+```
+
+Then inspect `/tmp/pim-smoke/<run-id>/<task>/agent/pim_agent.log` and `pim.log` to confirm Bun installed, the pim bind-mount resolved, and pim emitted a sensible JSONL stream.
+
+## Troubleshooting
+
+- **`extra_docker_compose` ignored** — verify `harbor run` accepts `--extra-docker-compose <path>`; older harbor versions used a different flag.
+- **`bun: command not found`** in container — install step failed; check `install` logs in the trial output dir.
+- **Model unreachable** — from inside a task container, `curl http://host.docker.internal:8888/v1/models` should return JSON. On Linux this requires `host.docker.internal:host-gateway` from `overlay.yaml`.
+- **`@earendil-works/pi-coding-agent` not found** — `bun install -g` failed; check container has egress (`allow_internet=true` in task `[environment]`).
+- **Pim tools error in `--print` mode** — TUI-only extensions may misbehave with `--print`. If so, narrow with `--tools Read,Write,Edit,Bash,Glob,Grep,WebFetch,WebSearch` (modify `adapter.py:_build_pim_command`).

--- a/benchmarks/terminal_bench_2/adapter.py
+++ b/benchmarks/terminal_bench_2/adapter.py
@@ -153,9 +153,8 @@ class PimAgent(BaseInstalledAgent):
         # Pipe through filter.py to drop streaming-delta event bloat - pim's
         # raw JSON output is ~1 GB per task, the filter reduces that ~1000x
         # while preserving message_end events (content + usage).
-        # Prepend a space to the instruction: pi's CLI parser doesn't honour
-        # `--`, so a prompt that starts with `-` (e.g. tb2 pytorch-model-recovery)
-        # gets parsed as an unknown flag and exits before the agent runs.
+        # `--` hands the raw instruction to pim, which forwards it via pi's
+        # stdin so prompts starting with `-` aren't parsed as flags.
         return (
             "set -e; "
             'export PATH="$HOME/.bun/bin:$PATH"; '
@@ -165,7 +164,7 @@ class PimAgent(BaseInstalledAgent):
             "done; "
             f"bun {CONTAINER_PIM_DIR}/bin/pim.ts "
             "--print --mode json --no-session --no-context-files "
-            f"--model {shlex.quote(model)} $EXTS {shlex.quote(' ' + instruction)} "
+            f"--model {shlex.quote(model)} $EXTS -- {shlex.quote(instruction)} "
             "2>&1 </dev/null "
             f"| python3 -u {CONTAINER_PIM_DIR}/benchmarks/terminal_bench_2/filter.py "
             f"| stdbuf -oL tee /logs/agent/{OUTPUT_FILENAME}"

--- a/benchmarks/terminal_bench_2/adapter.py
+++ b/benchmarks/terminal_bench_2/adapter.py
@@ -1,0 +1,209 @@
+"""Harbor BaseInstalledAgent adapter for Pim Agent on Terminal-Bench 2.0.
+
+Pim source is bind-mounted at /opt/pim by overlay.yaml. install() installs
+Bun and the pi-coding-agent CLI globally so pim's launcher can resolve them.
+run() shells out to `bun /opt/pim/bin/pim.ts --print --mode json ...` and
+tees pim's JSONL event stream to /logs/agent/pim.txt; post-run we parse
+that log for token usage and cost.
+
+Modelled on harbor.agents.installed.pi.Pi.
+
+Launch:
+
+    ./benchmarks/terminal_bench_2/run.sh
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from pathlib import Path
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+CONTAINER_PIM_DIR = "/opt/pim"
+LOG_DIR = "/logs/agent"
+OUTPUT_FILENAME = "pim.txt"
+DEFAULT_TIMEOUT_SEC = 10800  # 3h
+
+HOST_PI_MODELS = Path.home() / ".pi" / "agent" / "models.json"
+
+
+class PimAgent(BaseInstalledAgent):
+    """Pim Agent on Terminal-Bench 2.0 via Harbor's installed-agent flow."""
+
+    _OUTPUT_FILENAME = OUTPUT_FILENAME
+
+    @staticmethod
+    def name() -> str:
+        return "pim"
+
+    def get_version_command(self) -> str | None:
+        return (
+            'export PATH="$HOME/.bun/bin:$PATH"; '
+            f"bun {CONTAINER_PIM_DIR}/bin/pim.ts --version"
+        )
+
+    def parse_version(self, stdout: str) -> str:
+        return stdout.strip().splitlines()[-1].strip()
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        await self.exec_as_root(
+            environment,
+            command=(
+                "apt-get update && "
+                "apt-get install -y --no-install-recommends "
+                "curl ca-certificates unzip git coreutils python3 && "
+                f"mkdir -p {LOG_DIR} && chmod 0777 {LOG_DIR}"
+            ),
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+        )
+
+        # Install Bun for the agent user.
+        await self.exec_as_agent(
+            environment,
+            command="curl -fsSL https://bun.sh/install | bash",
+        )
+
+        # Install pi globally so pim's launcher resolves it.
+        await self.exec_as_agent(
+            environment,
+            command="~/.bun/bin/bun install -g @earendil-works/pi-coding-agent",
+        )
+
+        # Sanity-check the bind mount.
+        await self.exec_as_agent(
+            environment,
+            command=f"test -f {CONTAINER_PIM_DIR}/bin/pim.ts",
+        )
+
+        # Provision pi's models.json so the container's pi sees the same
+        # provider config as the host (custom baseUrl, model ids, etc.).
+        if HOST_PI_MODELS.exists():
+            models_json = HOST_PI_MODELS.read_text()
+            await self.exec_as_agent(
+                environment,
+                command=(
+                    "mkdir -p ~/.pi/agent && "
+                    'printf "%s" "$PIM_MODELS_JSON" > ~/.pi/agent/models.json'
+                ),
+                env={"PIM_MODELS_JSON": models_json},
+            )
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        if not self.model_name:
+            raise ValueError("model_name is required")
+
+        provider = self.model_name.split("/", 1)[0] if "/" in self.model_name else ""
+        env = self._collect_env(provider)
+
+        cmd = self._build_pim_command(self.model_name, instruction)
+
+        await self.exec_as_agent(
+            environment,
+            command=cmd,
+            env=env,
+            timeout_sec=DEFAULT_TIMEOUT_SEC,
+        )
+
+    @staticmethod
+    def _collect_env(provider: str) -> dict[str, str]:
+        """Forward host env vars the agent needs inside the container.
+
+        Local providers (ollama/llamacpp) get their baseUrl + apiKey from
+        the models.json written into the container during install(), so
+        no env vars are needed for them. Hosted-provider API keys and
+        web-tool keys are forwarded if set on the host.
+        """
+        env: dict[str, str] = {}
+
+        provider_keys: dict[str, list[str]] = {
+            "anthropic": ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"],
+            "openai": ["OPENAI_API_KEY"],
+            "google": [
+                "GEMINI_API_KEY",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+                "GOOGLE_API_KEY",
+            ],
+            "groq": ["GROQ_API_KEY"],
+            "openrouter": ["OPENROUTER_API_KEY"],
+            "mistral": ["MISTRAL_API_KEY"],
+            "xai": ["XAI_API_KEY"],
+        }
+        forward = provider_keys.get(provider, []) + ["EXA_API_KEY", "JINA_API_KEY"]
+        for key in forward:
+            val = os.environ.get(key)
+            if val:
+                env[key] = val
+        return env
+
+    @staticmethod
+    def _build_pim_command(model: str, instruction: str) -> str:
+        # pim.ts internally spawns `bun pm -g bin` to locate the global pi
+        # install, so bun must be on PATH (not just invoked by absolute path).
+        # Enumerate Pim's extensions at exec time; each needs its own -e flag.
+        # Pipe through filter.py to drop streaming-delta event bloat - pim's
+        # raw JSON output is ~1 GB per task, the filter reduces that ~1000x
+        # while preserving message_end events (content + usage).
+        # Prepend a space to the instruction: pi's CLI parser doesn't honour
+        # `--`, so a prompt that starts with `-` (e.g. tb2 pytorch-model-recovery)
+        # gets parsed as an unknown flag and exits before the agent runs.
+        return (
+            "set -e; "
+            'export PATH="$HOME/.bun/bin:$PATH"; '
+            "EXTS=''; "
+            f"for f in {CONTAINER_PIM_DIR}/src/extensions/*/index.ts; do "
+            "  EXTS=\"$EXTS -e $f\"; "
+            "done; "
+            f"bun {CONTAINER_PIM_DIR}/bin/pim.ts "
+            "--print --mode json --no-session --no-context-files "
+            f"--model {shlex.quote(model)} $EXTS {shlex.quote(' ' + instruction)} "
+            "2>&1 </dev/null "
+            f"| python3 -u {CONTAINER_PIM_DIR}/benchmarks/terminal_bench_2/filter.py "
+            f"| stdbuf -oL tee /logs/agent/{OUTPUT_FILENAME}"
+        )
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        output_file = self.logs_dir / OUTPUT_FILENAME
+        if not output_file.exists():
+            return
+
+        n_input = 0
+        n_output = 0
+        n_cache_read = 0
+        n_cache_write = 0
+        total_cost = 0.0
+
+        for raw in output_file.read_text().splitlines():
+            line = raw.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") != "message_end":
+                continue
+            message = event.get("message") or {}
+            if message.get("role") != "assistant":
+                continue
+            usage = message.get("usage") or {}
+            n_input += usage.get("input", 0)
+            n_output += usage.get("output", 0)
+            n_cache_read += usage.get("cacheRead", 0)
+            n_cache_write += usage.get("cacheWrite", 0)
+            cost = usage.get("cost") or {}
+            total_cost += cost.get("total", 0.0)
+
+        context.n_input_tokens = n_input + n_cache_read
+        context.n_output_tokens = n_output
+        context.n_cache_tokens = n_cache_read
+        context.cost_usd = total_cost if total_cost > 0 else None

--- a/benchmarks/terminal_bench_2/filter.py
+++ b/benchmarks/terminal_bench_2/filter.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Streaming JSONL filter for pim's `--print --mode json` output.
+
+Pim's event stream is built for live-streaming UIs: each `*_delta` event
+carries a `partial` snapshot of the entire conversation so far, which
+makes the log balloon (~1 GB per task with Qwen3.6). For offline logging
+we only need the consolidated end-of-message state.
+
+This filter:
+  - Drops `*_delta` events and their `*_start` counterparts.
+  - Strips the bloated `partial` field from any event that retains it.
+  - Keeps `message_end` (which has the full accumulated content + usage),
+    `tool_execution_end`, `turn_end`, `agent_start`, `agent_end`, `session`.
+  - Passes through non-JSON lines verbatim (errors, etc.).
+
+Stays in lock-step with the model via line-buffered I/O.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+TOP_DROP = {
+    "tool_execution_start",
+    "turn_start",
+    "message_start",
+    "text_start",
+    "thinking_start",
+    "toolcall_start",
+    "thinking",
+    "text",
+    "toolCall",
+    "toolcall_delta",
+}
+
+INNER_DROP_SUFFIXES = ("_delta",)
+INNER_DROP_EXACT = {"thinking_start", "text_start", "toolcall_start", "toolCall"}
+
+
+def main() -> None:
+    out = sys.stdout
+    for raw in sys.stdin:
+        line = raw.rstrip("\r\n")
+        if not line:
+            continue
+        if not line.startswith("{"):
+            out.write(line + "\n")
+            out.flush()
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            out.write(line + "\n")
+            out.flush()
+            continue
+
+        t = ev.get("type", "")
+        if t in TOP_DROP:
+            continue
+
+        if t == "message_update":
+            inner = ev.get("assistantMessageEvent") or {}
+            it = inner.get("type", "")
+            if any(it.endswith(suf) for suf in INNER_DROP_SUFFIXES):
+                continue
+            if it in INNER_DROP_EXACT:
+                continue
+            inner.pop("partial", None)
+
+        out.write(json.dumps(ev, ensure_ascii=False) + "\n")
+        out.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/terminal_bench_2/overlay.yaml
+++ b/benchmarks/terminal_bench_2/overlay.yaml
@@ -1,0 +1,16 @@
+# Harbor docker-compose overlay for Pim Agent on Terminal-Bench 2.0.
+#
+# - extra_hosts: pins the Tailscale-resolved model-server hostname to its IP
+#   so requests from inside the container reach the right machine. Values
+#   come from env vars exported by run.sh (it parses host ~/.pi/agent/models.json
+#   and resolves the IP via getent).
+# - volumes: bind-mounts the pim source read-only into /opt/pim so install()
+#   doesn't have to clone or npm-install the repo per task. Edits on the host
+#   are picked up by the next task without rebuilding.
+
+services:
+  main:
+    extra_hosts:
+      - "${TB_LLM_HOST}:${TB_LLM_HOST_IP}"
+    volumes:
+      - ${PIM_REPO_ROOT}:/opt/pim:ro

--- a/benchmarks/terminal_bench_2/run.sh
+++ b/benchmarks/terminal_bench_2/run.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Run Pim Agent on Terminal-Bench 2.0 via Harbor's BaseInstalledAgent flow.
+#
+# Usage:
+#   ./benchmarks/terminal_bench_2/run.sh                # default output dir
+#   ./benchmarks/terminal_bench_2/run.sh /tmp/tb2-runs  # custom output dir
+#
+# Env overrides:
+#   TB_PIM_MODEL     model spec passed to pim (default: read from ~/.pi/agent/models.json)
+#   TB_N_CONCURRENT  number of parallel containers (default: 1)
+#   TB_TASK          run a single task by id (smoke testing)
+#   TB_DEBUG         set to 1 for harbor --debug
+#
+# Prerequisites:
+#   - Docker running
+#   - harbor installed (pip install harbor  OR  uv tool install harbor)
+#   - Pi's models.json present at ~/.pi/agent/models.json with a provider entry
+#   - Required host env vars set (see .env.example)
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+
+OUTPUT_DIR="${1:-$REPO_ROOT/benchmarks/terminal_bench_2/runs}"
+N_CONCURRENT="${TB_N_CONCURRENT:-1}"
+
+PI_MODELS="${HOME}/.pi/agent/models.json"
+
+if [ ! -f "$PI_MODELS" ]; then
+    echo "ERROR: pi models config not found at $PI_MODELS"
+    echo "       Create it (with a provider entry) before running this benchmark."
+    exit 1
+fi
+
+# Pluck the first baseUrl from pi's models.json, then host:port.
+LLM_URL=$(python3 -c "
+import json, sys
+cfg = json.load(open('$PI_MODELS'))
+providers = cfg.get('providers') or {}
+for name, p in providers.items():
+    if p.get('baseUrl'):
+        print(name, p['baseUrl'])
+        sys.exit(0)
+sys.exit('no provider with baseUrl in models.json')
+")
+TB_LLM_PROVIDER=$(echo "$LLM_URL" | awk '{print $1}')
+TB_LLM_HOST=$(echo "$LLM_URL" | awk '{print $2}' | sed -E 's#https?://##; s#[:/].*##')
+TB_LLM_HOST_IP=$(getent hosts "$TB_LLM_HOST" | awk '{print $1}' | head -1)
+
+if [ -z "$TB_LLM_HOST_IP" ]; then
+    echo "ERROR: could not resolve $TB_LLM_HOST"
+    echo "       Check Tailscale / DNS on this host."
+    exit 1
+fi
+
+# Default model: first model id under the resolved provider.
+DEFAULT_MODEL=$(python3 -c "
+import json
+cfg = json.load(open('$PI_MODELS'))
+p = cfg['providers']['$TB_LLM_PROVIDER']
+models = p.get('models') or []
+if not models:
+    raise SystemExit('no models under $TB_LLM_PROVIDER in models.json')
+print(f\"$TB_LLM_PROVIDER/{models[0]['id']}\")
+")
+MODEL="${TB_PIM_MODEL:-$DEFAULT_MODEL}"
+
+echo "=== Pim Agent · Terminal-Bench 2.0 (installed-agent) ==="
+echo "Repo      : $REPO_ROOT"
+echo "Provider  : $TB_LLM_PROVIDER"
+echo "Host      : $TB_LLM_HOST -> $TB_LLM_HOST_IP"
+echo "Model     : $MODEL"
+echo "Concurrent: $N_CONCURRENT"
+echo "Output    : $OUTPUT_DIR"
+[ -n "${TB_TASK:-}" ] && echo "Task      : $TB_TASK (single-task smoke)"
+echo "========================================================"
+
+command -v harbor >/dev/null || { echo "ERROR: harbor not found. pip install harbor"; exit 1; }
+command -v docker >/dev/null || { echo "ERROR: docker not found"; exit 1; }
+
+export PIM_REPO_ROOT="$REPO_ROOT"
+export TB_LLM_HOST TB_LLM_HOST_IP
+
+cd "$REPO_ROOT"
+
+EXTRA_ARGS=()
+if [ -n "${TB_TASK:-}" ]; then
+    EXTRA_ARGS+=(--include-task-name "$TB_TASK" --n-tasks 1)
+fi
+[ "${TB_DEBUG:-0}" = "1" ] && EXTRA_ARGS+=(--debug)
+
+harbor run \
+    --dataset terminal-bench@2.0 \
+    --agent-import-path benchmarks.terminal_bench_2.adapter:PimAgent \
+    --extra-docker-compose "$HERE/overlay.yaml" \
+    --model "$MODEL" \
+    --jobs-dir "$OUTPUT_DIR" \
+    --n-concurrent "$N_CONCURRENT" \
+    --yes \
+    "${EXTRA_ARGS[@]}"

--- a/bin/pim.ts
+++ b/bin/pim.ts
@@ -43,6 +43,16 @@ function resolveGlobalPiCli(): string | null {
 }
 
 const cliArgs = process.argv.slice(2);
+
+// Pi's argparse rejects prompts beginning with `-` and doesn't honour `--`
+// itself; do the split here and forward the prompt via pi's stdin instead.
+const dashDashIdx = cliArgs.indexOf("--");
+let promptViaStdin: string | undefined;
+if (dashDashIdx >= 0) {
+  promptViaStdin = cliArgs.slice(dashDashIdx + 1).join(" ");
+  cliArgs.length = dashDashIdx;
+}
+
 const modeIdx = cliArgs.findIndex(
   (a) => a === "--mode" || a.startsWith("--mode=")
 );
@@ -70,10 +80,18 @@ if (mode === "telegram") {
 
 const piCli = findPiCli();
 const proc = Bun.spawn({
-  cmd: [process.execPath, piCli, ...process.argv.slice(2)],
-  stdio: ["inherit", "inherit", "inherit"],
+  cmd: [process.execPath, piCli, ...cliArgs],
+  stdio: [
+    promptViaStdin === undefined ? "inherit" : "pipe",
+    "inherit",
+    "inherit",
+  ],
   env: process.env,
 });
+if (promptViaStdin !== undefined && proc.stdin) {
+  proc.stdin.write(promptViaStdin);
+  proc.stdin.end();
+}
 // Forward shutdown signals so pi's bash subtrees aren't orphaned on the host.
 for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
   process.once(sig, () => {


### PR DESCRIPTION
## Summary

- Add `benchmarks/terminal_bench_2/` — a Harbor `BaseInstalledAgent` adapter that runs Pim Agent against [Terminal-Bench 2.0](https://www.tbench.ai/leaderboard/terminal-bench/2.0).
- Pim source bind-mounts into each task container at `/opt/pim` via the docker-compose overlay; all of Pim's tools run natively in-container against the task workspace.
- `run.sh` resolves the model-server hostname + IP from `~/.pi/agent/models.json` and pipes the per-task event stream through `filter.py` to keep logs manageable.
- `adapter.py` prepends a single space to the task instruction — pi's CLI parser treats a leading `-` as an unknown option, which would otherwise crash on tasks like `pytorch-model-recovery` whose prompts start with a dash.
- `.gitignore` excludes the per-run output directories and `__pycache__`.

## Test plan

- [x] `bun run check` passes
- [x] Smoke-tested end-to-end on the full TB2 dataset (89 tasks)
- [x] No personal info, hostnames, IPs, or run artifacts staged (verified by grep + .gitignore for `benchmarks/*/runs/`)